### PR TITLE
refactor: remove route drawing tool button from sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 function App() {
   const [selectedElement] = useState<string | null>(null);
   const [currentTool, setCurrentTool] = useState<
-    'select' | 'player' | 'route' | 'eraser'
+    'select' | 'player' | 'eraser'
   >('select');
   const [selectedPlayerId, setSelectedPlayerId] = useState<string | null>(null);
   const [startRouteDrawing, setStartRouteDrawing] = useState<{
@@ -91,36 +91,6 @@ function App() {
                 strokeLinejoin="round"
                 strokeWidth={2}
                 d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-              />
-            </svg>
-          </button>
-          {/* Route Drawing Tool */}
-          {/* TODO: パスルートやランプレイの動きを描画するツール
-           * - 線種（実線、破線、点線、ジグザグ）
-           * - 矢印、ブロック、丸などの終端記号
-           * - ルートの深さ（ヤード数）表示
-           * - プレスナップモーションの表現
-           */}
-          <button
-            title="Draw Route"
-            className={`w-10 h-10 flex items-center justify-center rounded transition-colors ${
-              currentTool === 'route'
-                ? 'bg-blue-500 text-white hover:bg-blue-600'
-                : 'hover:bg-blue-50 text-gray-600 hover:text-blue-600'
-            }`}
-            onClick={() => setCurrentTool('route')}
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13 5l7 7-7 7M5 5l7 7-7 7"
               />
             </svg>
           </button>

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -18,7 +18,6 @@ describe('App', () => {
     render(<App />);
     expect(screen.getByTitle('Select')).toBeInTheDocument();
     expect(screen.getByTitle('Add Player')).toBeInTheDocument();
-    expect(screen.getByTitle('Draw Route')).toBeInTheDocument();
     expect(screen.getByTitle('Formations')).toBeInTheDocument();
     expect(screen.getByTitle('Add Text')).toBeInTheDocument();
     expect(screen.getByTitle('Blocking')).toBeInTheDocument();

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -3,7 +3,7 @@ import { useRef, useEffect, useState } from 'react';
 interface FieldProps {
   width?: number;
   height?: number;
-  currentTool?: 'select' | 'player' | 'route' | 'eraser';
+  currentTool?: 'select' | 'player' | 'eraser';
   selectedPlayerId?: string | null;
   onPlayerSelect?: (playerId: string | null) => void;
   startRouteDrawing?: {
@@ -929,7 +929,7 @@ const Field = ({
             ? 'copy'
             : currentTool === 'eraser'
               ? 'not-allowed'
-              : currentTool === 'route' || isDrawingMode
+              : isDrawingMode
                 ? 'crosshair'
                 : draggingPlayer || draggingLine || draggingPoint
                   ? 'grabbing'


### PR DESCRIPTION
### Summary

This pull request introduces commit `e86f6fc` on branch `refactor/remove-route-drawing-tool-button-from-si-20250711`.

### Checklist

- [ ] Code builds and unit tests pass locally
- [ ] Relevant documentation updated
- [ ] Reviewer has sufficient context

### Motivation and Context

This refactoring removes the route drawing tool button from the left sidebar to simplify the UI. The route drawing functionality remains accessible through the right-click context menu on players, providing a more contextual and streamlined user experience.

### Implementation Details

The following changes were made:

- **src/App.tsx**: Removed the route drawing tool button component and its associated TODO comments from the left sidebar
- **src/components/Field.tsx**: Updated the type definitions to remove the 'route' tool option from the currentTool prop, while maintaining route drawing functionality through the context menu

The route drawing feature itself remains fully functional - users can still draw routes by right-clicking on players and selecting "Draw Route" from the context menu.

### Testing Instructions

To verify the changes work correctly:

1. Run the application with `pnpm run dev`
2. Verify the route drawing button is no longer visible in the left sidebar
3. Right-click on any player on the field
4. Select "Draw Route" from the context menu
5. Confirm route drawing still works as expected
6. Verify all other tools in the sidebar continue to function normally

### Related Issues

N/A

### Notes for Release

Simplified UI by removing the route drawing tool button from the sidebar. Route drawing functionality remains available through the player context menu.