### PR TITLE
feat: add player shape and color customization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import Field from './components/Field';
+import Field, { type Player } from './components/Field';
 import { useState } from 'react';
 
 function App() {
@@ -7,10 +7,23 @@ function App() {
     'select' | 'player' | 'eraser'
   >('select');
   const [selectedPlayerId, setSelectedPlayerId] = useState<string | null>(null);
+  const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
+  const [players, setPlayers] = useState<Player[]>([]);
   const [startRouteDrawing, setStartRouteDrawing] = useState<{
     playerId: string;
     routeType: 'solid' | 'dashed' | 'dotted';
   } | null>(null);
+
+  const updatePlayer = (playerId: string, updates: Partial<Player>) => {
+    setPlayers((prevPlayers) =>
+      prevPlayers.map((player) =>
+        player.id === playerId ? { ...player, ...updates } : player,
+      ),
+    );
+    if (selectedPlayer && selectedPlayer.id === playerId) {
+      setSelectedPlayer({ ...selectedPlayer, ...updates });
+    }
+  };
 
   const handleExport = () => {
     const canvas = document.querySelector('canvas');
@@ -393,7 +406,15 @@ function App() {
             <Field
               currentTool={currentTool}
               selectedPlayerId={selectedPlayerId}
-              onPlayerSelect={setSelectedPlayerId}
+              players={players}
+              onPlayersChange={setPlayers}
+              onPlayerSelect={(playerId, player) => {
+                setSelectedPlayerId(playerId);
+                setSelectedPlayer(player || null);
+              }}
+              onPlayerUpdate={(playerId, updates) => {
+                updatePlayer(playerId, updates);
+              }}
               startRouteDrawing={startRouteDrawing}
               onRouteDrawingStart={setStartRouteDrawing}
             />
@@ -409,6 +430,78 @@ function App() {
               <div>
                 <label className="block text-xs text-gray-500 mb-1">Type</label>
                 <div className="text-sm text-gray-700">Player</div>
+              </div>
+
+              {/* Shape Selection */}
+              <div>
+                <label className="block text-xs text-gray-500 mb-2">
+                  Shape
+                </label>
+                <div className="grid grid-cols-2 gap-2">
+                  <button
+                    className={`p-2 flex items-center justify-center rounded border transition-all ${
+                      selectedPlayer?.shape === 'circle'
+                        ? 'bg-blue-500 text-white border-blue-600'
+                        : 'bg-white hover:bg-blue-50 text-gray-600 hover:text-blue-600 border-gray-300'
+                    }`}
+                    onClick={() => {
+                      if (selectedPlayer) {
+                        updatePlayer(selectedPlayer.id, { shape: 'circle' });
+                      }
+                    }}
+                  >
+                    <div className="w-5 h-5 rounded-full border-2 border-current" />
+                  </button>
+                  <button
+                    className={`p-2 flex items-center justify-center rounded border transition-all ${
+                      selectedPlayer?.shape === 'square'
+                        ? 'bg-blue-500 text-white border-blue-600'
+                        : 'bg-white hover:bg-blue-50 text-gray-600 hover:text-blue-600 border-gray-300'
+                    }`}
+                    onClick={() => {
+                      if (selectedPlayer) {
+                        updatePlayer(selectedPlayer.id, { shape: 'square' });
+                      }
+                    }}
+                  >
+                    <div className="w-5 h-5 border-2 border-current" />
+                  </button>
+                </div>
+              </div>
+
+              {/* Color Selection */}
+              <div>
+                <label className="block text-xs text-gray-500 mb-2">
+                  Color
+                </label>
+                <div className="grid grid-cols-3 gap-2">
+                  {[
+                    { name: 'Blue', value: '#3B82F6' },
+                    { name: 'Red', value: '#EF4444' },
+                    { name: 'Green', value: '#10B981' },
+                    { name: 'Yellow', value: '#F59E0B' },
+                    { name: 'Purple', value: '#8B5CF6' },
+                    { name: 'Pink', value: '#EC4899' },
+                  ].map((color) => (
+                    <button
+                      key={color.value}
+                      title={color.name}
+                      className={`p-2 rounded border-2 transition-all ${
+                        selectedPlayer?.color === color.value
+                          ? 'border-gray-800 shadow-md'
+                          : 'border-gray-300 hover:border-gray-500'
+                      }`}
+                      style={{ backgroundColor: color.value }}
+                      onClick={() => {
+                        if (selectedPlayer) {
+                          updatePlayer(selectedPlayer.id, {
+                            color: color.value,
+                          });
+                        }
+                      }}
+                    />
+                  ))}
+                </div>
               </div>
 
               {/* Route Drawing Options */}


### PR DESCRIPTION
## Summary

This pull request introduces commit `fbda62c` on branch `feat/add-player-shape-and-color-customization-20250711`.

## Checklist

- [ ] Code builds and unit tests pass locally
- [ ] Relevant documentation updated
- [ ] Reviewer has sufficient context

## Motivation and Context

This feature enhances the play diagram editor by allowing users to customize player appearance on the field. Different shapes and colors help distinguish between various player positions and teams, making it easier to create clear and understandable play diagrams. This is a fundamental feature for any football play diagramming tool.

## Implementation Details

Modified files:
- **src/App.tsx** (+97 lines): Added player state management and UI controls for customization
- **src/components/Field.tsx** (+91 lines, -19 lines): Updated to support external player state and real-time updates

Key implementation changes:

1. **Player State Management**: Lifted player state from Field component to App component for centralized control
2. **Shape Selection**: Added UI controls to switch between circle and square player shapes
3. **Color Palette**: Implemented a 6-color palette (Blue, Red, Green, Yellow, Purple, Pink) for player customization
4. **Real-time Updates**: Players update immediately when shape or color is changed in the right sidebar
5. **Property Panel Integration**: Added shape and color controls to the right sidebar that appears when a player is selected

## Testing Instructions

1. Run the application with `pnpm run dev`
2. Select the player tool and place a player on the field
3. Click on the placed player to select it
4. In the right sidebar, test the shape selection:
   - Click the circle button to set player shape to circle
   - Click the square button to set player shape to square
   - Verify the player updates immediately on the field
5. Test the color selection:
   - Click any of the 6 color options
   - Verify the player color changes immediately
   - Verify the selected color shows a border indicator
6. Place multiple players and verify each can have different shapes and colors
7. Test that player properties persist when selecting different players

## Related Issues

N/A

## Notes for Release

Added player customization features allowing users to change player shapes (circle/square) and colors (6 color options) through the property panel. This enhances the visual clarity of play diagrams.