### PR TITLE
feat: auto-switch to select tool after placing player

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -415,6 +415,7 @@ function App() {
               onPlayerUpdate={(playerId, updates) => {
                 updatePlayer(playerId, updates);
               }}
+              onToolChange={setCurrentTool}
               startRouteDrawing={startRouteDrawing}
               onRouteDrawingStart={setStartRouteDrawing}
             />

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -9,6 +9,7 @@ interface FieldProps {
   onPlayersChange?: (players: Player[]) => void;
   onPlayerSelect?: (playerId: string | null, player?: Player) => void;
   onPlayerUpdate?: (playerId: string, updates: Partial<Player>) => void;
+  onToolChange?: (tool: 'select' | 'player' | 'eraser') => void;
   startRouteDrawing?: {
     playerId: string;
     routeType: 'solid' | 'dashed' | 'dotted';
@@ -85,6 +86,7 @@ const Field = ({
   onPlayersChange,
   onPlayerSelect,
   onPlayerUpdate,
+  onToolChange,
   startRouteDrawing,
   onRouteDrawingStart,
 }: FieldProps) => {
@@ -639,6 +641,9 @@ const Field = ({
         color: '#3B82F6', // デフォルトは青色
       };
       setPlayers([...players, newPlayer]);
+
+      // 選手を追加したら選択モードに戻る
+      onToolChange?.('select');
     } else if (currentTool === 'eraser') {
       // 消しゴムモード - プレイヤーをクリックして削除
       for (const player of players) {


### PR DESCRIPTION
### Summary

This pull request introduces commit `9ba4d19` on branch `feat/auto-switch-to-select-tool-after-placing-20250711`.

### Checklist

- [ ] Code builds and unit tests pass locally
- [ ] Relevant documentation updated
- [ ] Reviewer has sufficient context

### Motivation and Context

This feature improves the user experience by automatically switching back to the select tool after placing a player on the field. This eliminates the need for manual tool switching, making the workflow more intuitive and efficient for users who need to place multiple players and adjust their positions.

### Implementation Details

The implementation modifies two key files:

- **src/App.tsx**: Updated the state management logic to automatically set the active tool back to 'select' after a player placement operation completes
- **src/components/Field.tsx**: Modified the player placement handler to trigger the tool switch after successfully adding a new player to the field

The change ensures that after placing a player, users can immediately select and manipulate it without needing to manually switch tools.

### Testing Instructions

To verify this functionality works correctly:

1. Open the application and ensure the field is displayed
2. Click on the player placement tool in the toolbar
3. Click anywhere on the field to place a player
4. Verify that:
   - The player is placed at the clicked position
   - The active tool automatically switches back to the select tool
   - The select tool icon is highlighted in the toolbar
5. Test edge cases:
   - Place multiple players in succession
   - Try to place a player outside the field boundaries
   - Ensure the tool switch happens consistently

### Related Issues

N/A

### Notes for Release

Improved workflow: The select tool is now automatically activated after placing a player, streamlining the player positioning process.