### PR TITLE
feat: add player label functionality with visual display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -470,6 +470,27 @@ function App() {
                 </div>
               </div>
 
+              {/* Label Input */}
+              <div>
+                <label className="block text-xs text-gray-500 mb-2">
+                  Label
+                </label>
+                <input
+                  type="text"
+                  value={selectedPlayer?.label || ''}
+                  onChange={(e) => {
+                    if (selectedPlayer) {
+                      updatePlayer(selectedPlayer.id, {
+                        label: e.target.value,
+                      });
+                    }
+                  }}
+                  placeholder="X, Y, DE, 8, 82..."
+                  className="w-full bg-gray-50 border border-gray-300 rounded px-3 py-2 text-sm text-gray-700 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none"
+                  maxLength={4}
+                />
+              </div>
+
               {/* Color Selection */}
               <div>
                 <label className="block text-xs text-gray-500 mb-2">
@@ -595,48 +616,12 @@ function App() {
                   </p>
                 )}
               </div>
-
-              {/* Position */}
-              <div>
-                <label className="block text-xs text-gray-500 mb-1">
-                  Position
-                </label>
-                <div className="grid grid-cols-2 gap-2">
-                  <input
-                    type="number"
-                    placeholder="X"
-                    className="bg-gray-50 border border-gray-300 rounded px-2 py-1 text-sm text-gray-700 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none"
-                  />
-                  <input
-                    type="number"
-                    placeholder="Y"
-                    className="bg-gray-50 border border-gray-300 rounded px-2 py-1 text-sm text-gray-700 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none"
-                  />
-                </div>
-              </div>
             </div>
           ) : selectedElement ? (
             <div className="space-y-4">
               <div>
                 <label className="block text-xs text-gray-500 mb-1">Type</label>
                 <div className="text-sm text-gray-700">{selectedElement}</div>
-              </div>
-              <div>
-                <label className="block text-xs text-gray-500 mb-1">
-                  Position
-                </label>
-                <div className="grid grid-cols-2 gap-2">
-                  <input
-                    type="number"
-                    placeholder="X"
-                    className="bg-gray-50 border border-gray-300 rounded px-2 py-1 text-sm text-gray-700 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none"
-                  />
-                  <input
-                    type="number"
-                    placeholder="Y"
-                    className="bg-gray-50 border border-gray-300 rounded px-2 py-1 text-sm text-gray-700 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none"
-                  />
-                </div>
               </div>
             </div>
           ) : (

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,6 +1,13 @@
 import { vi } from 'vitest';
 import '@testing-library/jest-dom';
 
+// devicePixelRatioをモック
+Object.defineProperty(window, 'devicePixelRatio', {
+  value: 1,
+  writable: true,
+  configurable: true,
+});
+
 // Mock canvas context
 const mockCanvasContext = {
   fillStyle: '',
@@ -19,6 +26,7 @@ const mockCanvasContext = {
   fill: vi.fn(),
   arc: vi.fn(),
   fillText: vi.fn(),
+  strokeText: vi.fn(),
   save: vi.fn(),
   restore: vi.fn(),
   translate: vi.fn(),

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -29,6 +29,7 @@ interface Player {
   team: 'offense' | 'defense';
   shape: 'circle' | 'square';
   color: string;
+  label?: string;
 }
 
 interface Line {
@@ -146,6 +147,7 @@ const Field = ({
           team: 'offense',
           shape: 'circle',
           color: '#3B82F6',
+          label: 'X',
         },
         {
           id: 'defensive-1',
@@ -154,6 +156,7 @@ const Field = ({
           team: 'defense',
           shape: 'circle',
           color: '#EF4444',
+          label: 'DE',
         },
       ]);
     }
@@ -187,6 +190,22 @@ const Field = ({
 
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
+
+    // 高解像度ディスプレイ対応
+    const dpr = window.devicePixelRatio || 1;
+
+    // Canvasの実際のサイズを設定
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+
+    // CSSサイズを維持
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+
+    // コンテキストをスケール
+    if (ctx.scale) {
+      ctx.scale(dpr, dpr);
+    }
 
     // フィールドの緑色背景
     ctx.fillStyle = '#4a7c59';
@@ -566,6 +585,30 @@ const Field = ({
           ctx.stroke();
         }
       }
+
+      // ラベルを描画
+      if (player.label) {
+        ctx.save();
+
+        // テキストのスタイル設定
+        ctx.fillStyle = '#FFFFFF'; // 白文字
+        ctx.strokeStyle = player.color || '#3B82F6'; // 背景色で縁取り
+        ctx.lineWidth = 3;
+        ctx.font = `bold ${playerRadius * 0.8}px Arial`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+
+        // フォントのメトリクスを考慮した調整
+        const textY = player.y + playerRadius * 0.1; // 少し下に調整
+
+        // テキストに縁取りをつけて描画
+        if (ctx.strokeText) {
+          ctx.strokeText(player.label, player.x, textY);
+        }
+        ctx.fillText(player.label, player.x, textY);
+
+        ctx.restore();
+      }
     });
   }, [
     width,
@@ -639,6 +682,7 @@ const Field = ({
         team: 'offense',
         shape: 'circle',
         color: '#3B82F6', // デフォルトは青色
+        label: '', // デフォルトは空
       };
       setPlayers([...players, newPlayer]);
 
@@ -976,8 +1020,6 @@ const Field = ({
   return (
     <canvas
       ref={canvasRef}
-      width={width}
-      height={height}
       className="border border-gray-300 shadow-lg"
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}


### PR DESCRIPTION
## Summary

This pull request introduces commit `5df3995` on branch `feat/add-player-labels-and-improve-canvas-ren-20250712`.

### Checklist

- [x] Code builds and unit tests pass locally
- [x] Relevant documentation updated
- [x] Reviewer has sufficient context

### Motivation and Context

This change enhances the play diagram editor by adding player labeling functionality, which is essential for creating clear and informative football play diagrams. Players can now be identified with custom labels (like position codes or jersey numbers), making it easier to communicate plays and formations. Additionally, the high-DPI display support ensures that the canvas renders sharply on modern screens.

### Implementation Details

**Files Modified:**
- `src/App.tsx`: Added label input field to the properties panel, allowing users to enter custom labels for selected players (max 4 characters)
- `src/components/Field.tsx`: 
  - Added `label` property to the Player interface
  - Implemented label rendering logic in the canvas drawing function
  - Added high-DPI display support using devicePixelRatio for crisp rendering
  - Set default labels for initial players (X for offense, DE for defense)
- `src/__tests__/setup.ts`: Added `strokeText` mock to support label rendering in tests

**Key Technical Decisions:**
- Labels are rendered with white text and colored outline for visibility against the field background
- Text size is proportional to player radius for consistent appearance
- Canvas scaling uses devicePixelRatio to ensure sharp rendering on retina displays
- Removed redundant position input fields from properties panel to simplify UI

### Testing Instructions

1. **Test label functionality:**
   - Run the application with `pnpm run dev`
   - Click on any player on the field
   - Enter a label in the "Label" field in the right properties panel
   - Verify the label appears centered on the player shape
   - Try different labels (letters, numbers, position codes)

2. **Test high-DPI rendering:**
   - View the application on a high-DPI display (if available)
   - Verify that player shapes and labels appear sharp, not blurry
   - Compare with previous rendering quality

3. **Edge cases to verify:**
   - Empty labels should not display anything
   - Labels with 4+ characters should be truncated
   - Labels should be visible on both offense (blue) and defense (red) players
   - Label styling should match the player's color

### Related Issues

N/A

### Notes for Release

- Players can now have custom labels (up to 4 characters) displayed on their shapes
- Canvas rendering improved for high-resolution displays
- Default players now include example labels (X for offense, DE for defense)