### PR TITLE
ci: Dependabot による依存自動更新を導入する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot による依存自動更新設定
+# 方針: 常に最新（メジャー含む）を追随する。
+#  - minor / patch はエコシステムごとにまとめて 1 PR（ノイズ削減）
+#  - major は個別 PR（破壊的変更を 1 件ずつレビューするため、あえてグループ化しない）
+version: 2
+
+updates:
+  # npm（pnpm） — package.json / pnpm-lock.yaml
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    # package.json の指定レンジ自体も最新へ引き上げる（lockfile 追従だけにしない）
+    versioning-strategy: increase
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+    groups:
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions — .github/workflows/*
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
### Summary

This pull request introduces commit `f15ae83` on branch `feature/dependabot-20260516-112147`.

### Checklist

- [x] Code builds and unit tests pass locally
- [x] Relevant documentation updated
- [x] Reviewer has sufficient context

### Motivation and Context

依存を常に最新（メジャー含む）へ追随する方針を、手動更新から自動化するため。<br>
これまで `chore(deps)` / `ci` コミットで手作業更新していた npm（pnpm）と GitHub Actions を Dependabot で継続的に検知する。

### Implementation Details

`.github/dependabot.yml` を追加し、npm（pnpm）と github-actions の 2 エコシステムを週次でチェックする。<br>
`versioning-strategy: increase` で lockfile だけでなく `package.json` の指定レンジ自体も最新へ引き上げる。<br>
minor/patch はエコシステムごとにグループ化してノイズを抑え、major は破壊的変更を 1 件ずつレビューできるよう個別 PR とする。<br>
コミット prefix は本リポジトリの慣習に合わせ npm=`chore(deps)`（dev=`chore(deps-dev)`）、github-actions=`ci`。

### Testing Instructions

`.github/dependabot.yml` を YAML として確認する。<br>
設定はデフォルトブランチ（`main`）へマージ後に有効化され、GitHub の Insights › Dependency graph › Dependabot で動作を確認できる。

### Related Issues

特になし。

### Notes for Release

なし（CI/開発基盤の変更でユーザー向け影響なし）。
