### PR TITLE
feat: M5 編集 UI（ツール/プロパティ/Undo·Redo/view⇄edit）を実装する

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -47,8 +47,9 @@
   <body>
     <div id="app">
       <header>
-        <span>Playmaker Playground — M3: 線（view モード完成）</span>
+        <span>Playmaker Playground — M5: 編集 UI（ツール/プロパティ/Undo·Redo）</span>
         <div id="controls"></div>
+        <span id="status" style="margin-left: auto; opacity: 0.7"></span>
       </header>
       <div id="stage"></div>
     </div>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,38 +1,42 @@
 // ローカル確認用 playground のエントリ。
 // M1: フィールド描画 + ゾーン切替。M2: PlayData 投入で選手表示。
-// M3: 線（route/block/motion・直線/ベジェ）を表示し、view モードで読み取り専用表示。
-// 以降のマイルストーンで編集 UI / PNG 出力 / Undo・Redo を足していく。
-import { type FieldZone, type Line, type Player, Playmaker, type PlaymakerMode } from "playmaker";
+// M3: 線（route/block/motion・直線/ベジェ）+ view モード。
+// M5: 編集 UI（ツールバー/プロパティパネル/Undo·Redo/ゾーン切替）。
+//     ツール・プロパティ編集・ゾーン切替・Undo/Redo は Playmaker 内蔵 UI で操作する。
+//     ここではサンプル投入・クリア・mode 切替と、onChange のデータ連携を目視する。
+import {
+  type Line,
+  type PlayData,
+  type Player,
+  Playmaker,
+  type PlaymakerMode,
+  type PlaymakerOptions,
+} from "playmaker";
 
 const stage = document.getElementById("stage");
 const controlsEl = document.getElementById("controls");
-if (!stage || !controlsEl) {
-  throw new Error("#stage または #controls が見つかりません");
+const statusEl = document.getElementById("status");
+if (!stage || !controlsEl || !statusEl) {
+  throw new Error("#stage / #controls / #status が見つかりません");
 }
-// クロージャ内でも非 null として扱えるよう絞り込み済み参照を確定する。
 const controls: HTMLElement = controlsEl;
-// 非 null に絞り込んだ stage 参照（再マウントで使い回す）。
+const status: HTMLElement = statusEl;
 const mountPoint: HTMLElement = stage;
 
-// M2 目視用サンプル: 6 形状すべて・色指定・ラベルを含む攻守の隊形。
-// フィールド幅 ≈ 53.3yd（中央 ≈ 26.7）、middle ゾーンの LOS を 50yd に置く。
+// M2/M3 目視用サンプル: 6 形状・色・ラベル・3 線種・直線/ベジェ・waypoint。
 const DEFENSE_COLOR = "#c62828";
 const SAMPLE_PLAYERS: Player[] = [
-  // オフェンス OL（四角・既定色）
   { id: "ol-c", position: { lateralYard: 26.7, absoluteYard: 49 }, shape: "square", label: "C" },
   { id: "ol-lg", position: { lateralYard: 24.4, absoluteYard: 49 }, shape: "square", label: "LG" },
   { id: "ol-rg", position: { lateralYard: 29, absoluteYard: 49 }, shape: "square", label: "RG" },
   { id: "ol-lt", position: { lateralYard: 22.1, absoluteYard: 49 }, shape: "square", label: "LT" },
   { id: "ol-rt", position: { lateralYard: 31.3, absoluteYard: 49 }, shape: "square", label: "RT" },
-  // バックス（丸）・RB（菱形）
   { id: "qb", position: { lateralYard: 26.7, absoluteYard: 46.5 }, shape: "circle", label: "QB" },
   { id: "rb", position: { lateralYard: 26.7, absoluteYard: 43 }, shape: "diamond", label: "RB" },
-  // レシーバー（丸）・TE（三角）
   { id: "wr-x", position: { lateralYard: 7, absoluteYard: 49.5 }, shape: "circle", label: "X" },
   { id: "wr-z", position: { lateralYard: 46, absoluteYard: 49.5 }, shape: "circle", label: "Z" },
   { id: "wr-y", position: { lateralYard: 38, absoluteYard: 48 }, shape: "circle", label: "Y" },
   { id: "te", position: { lateralYard: 33.6, absoluteYard: 49 }, shape: "triangle", label: "TE" },
-  // ディフェンス（五角形・六角形・指定色）
   {
     id: "dl-1",
     position: { lateralYard: 24.4, absoluteYard: 51 },
@@ -77,9 +81,7 @@ const SAMPLE_PLAYERS: Player[] = [
   },
 ];
 
-// M3 目視用サンプル: 3 線種 + 直線/ベジェ + waypoint + 色/太さ上書き。
 const SAMPLE_LINES: Line[] = [
-  // ルート（直線・矢印付き）: X の 10yd アウト。
   {
     id: "rt-x",
     kind: "route",
@@ -88,7 +90,6 @@ const SAMPLE_LINES: Line[] = [
     end: { lateralYard: 13, absoluteYard: 59 },
     interpolation: "straight",
   },
-  // ルート（ベジェ）: Z のカール（曲走路で waypoint を滑らかに通る）。
   {
     id: "rt-z",
     kind: "route",
@@ -100,7 +101,6 @@ const SAMPLE_LINES: Line[] = [
     end: { lateralYard: 44, absoluteYard: 56 },
     interpolation: "bezier",
   },
-  // ルート（ベジェ）: Y の深いクロス。
   {
     id: "rt-y",
     kind: "route",
@@ -109,7 +109,6 @@ const SAMPLE_LINES: Line[] = [
     end: { lateralYard: 18, absoluteYard: 61 },
     interpolation: "bezier",
   },
-  // ブロック（太線・矢印なし）: RT → 右 DL。
   {
     id: "bl-rt",
     kind: "block",
@@ -118,7 +117,6 @@ const SAMPLE_LINES: Line[] = [
     end: { lateralYard: 29.5, absoluteYard: 50.6 },
     interpolation: "straight",
   },
-  // ブロック（色上書き）: LT → 左 DL。
   {
     id: "bl-lt",
     kind: "block",
@@ -128,7 +126,6 @@ const SAMPLE_LINES: Line[] = [
     interpolation: "straight",
     color: "#90caf9",
   },
-  // モーション（破線）: RB のジェットモーション（スナップ前の横移動）。
   {
     id: "mo-rb",
     kind: "motion",
@@ -139,100 +136,74 @@ const SAMPLE_LINES: Line[] = [
   },
 ];
 
-const zones: { id: FieldZone; label: string }[] = [
-  { id: "own-redzone", label: "自陣レッドゾーン" },
-  { id: "middle", label: "中央" },
-  { id: "redzone", label: "相手レッドゾーン" },
-];
-
-// 表示中の状態（モード切替で作り直すため Playmaker の外で保持）。
 let mode: PlaymakerMode = "edit";
-let playmaker = new Playmaker(mountPoint, { mode });
+let changeCount = 0;
 
-function loadSample(): void {
+function onChange(data: PlayData): void {
+  changeCount += 1;
+  status.textContent = `onChange #${changeCount}｜選手 ${data.players.length}・線 ${data.lines.length}・ゾーン ${data.field.zone}`;
+}
+
+function create(initialData?: PlayData): Playmaker {
+  changeCount = 0;
+  status.textContent = "onChange 待ち（編集すると更新されます）";
+  // exactOptionalPropertyTypes: initialData は値があるときだけ持たせる。
+  const options: PlaymakerOptions = { mode, onChange };
+  if (initialData !== undefined) {
+    options.initialData = initialData;
+  }
+  return new Playmaker(mountPoint, options);
+}
+
+let playmaker = create({
+  version: 1,
+  field: { zone: "middle" },
+  players: SAMPLE_PLAYERS,
+  lines: SAMPLE_LINES,
+});
+
+function addAction(label: string, onClick: () => void): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.textContent = label;
+  button.addEventListener("click", onClick);
+  controls.appendChild(button);
+  return button;
+}
+
+addAction("サンプル隊形＋線を読み込む", () => {
   playmaker.setPlayData({
     version: 1,
     field: { zone: playmaker.fieldZone },
     players: SAMPLE_PLAYERS,
     lines: SAMPLE_LINES,
   });
-}
+});
 
-function clearPlay(): void {
+addAction("クリア", () => {
   playmaker.setPlayData({
     version: 1,
     field: { zone: playmaker.fieldZone },
     players: [],
     lines: [],
   });
-}
+});
 
-/** mode を切り替えて再マウントする（現在のプレー図はそのまま引き継ぐ）。 */
-function remountWithMode(next: PlaymakerMode): void {
+const modeButton = addAction("", () => {
+  // mode 切替は再マウント（現在のプレー図はそのまま引き継ぐ）。
   const snapshot = playmaker.getPlayData();
   playmaker.dispose();
-  mode = next;
-  playmaker = new Playmaker(mountPoint, { mode, initialData: snapshot });
-  syncControls();
-}
-
-// --- コントロール構築 ---
-
-const zoneButtons = zones.map(({ id, label }) => {
-  const button = document.createElement("button");
-  button.textContent = label;
-  button.addEventListener("click", () => {
-    playmaker.setFieldZone(id);
-    syncControls();
-  });
-  controls.appendChild(button);
-  return { id, button };
+  mode = mode === "edit" ? "view" : "edit";
+  playmaker = create(snapshot);
+  syncModeButton();
 });
 
-function addSeparator(): void {
-  const separator = document.createElement("span");
-  separator.textContent = "｜";
-  separator.setAttribute("aria-hidden", "true");
-  controls.appendChild(separator);
-}
-
-function addAction(label: string, onClick: () => void): void {
-  const button = document.createElement("button");
-  button.textContent = label;
-  button.addEventListener("click", onClick);
-  controls.appendChild(button);
-}
-
-addSeparator();
-addAction("サンプル隊形＋線を読み込む", () => {
-  loadSample();
-  syncControls();
-});
-addAction("クリア", () => {
-  clearPlay();
-  syncControls();
-});
-
-addSeparator();
-const modeButton = document.createElement("button");
-modeButton.addEventListener("click", () => {
-  remountWithMode(mode === "edit" ? "view" : "edit");
-});
-controls.appendChild(modeButton);
-
-function syncControls(): void {
-  const current = playmaker.fieldZone;
-  for (const { id, button } of zoneButtons) {
-    button.setAttribute("aria-pressed", String(id === current));
-  }
-  // view では編集 UI を出さない（M5 以降）。現状は読み取り専用表示の確認用。
+function syncModeButton(): void {
   modeButton.textContent = mode === "edit" ? "view モードへ" : "edit モードへ";
   modeButton.setAttribute("aria-pressed", String(mode === "view"));
 }
 
-syncControls();
+syncModeButton();
 
-// HMR で再マウントしてもインスタンスがリークしないよう破棄する。
 if (import.meta.hot) {
   import.meta.hot.dispose(() => playmaker.dispose());
 }

--- a/docs/plans/implementation-roadmap.md
+++ b/docs/plans/implementation-roadmap.md
@@ -148,6 +148,30 @@ PRD 5.4 の編集ロジック基盤を **common のみ・UI なし**で確定。
 - `playmaker.ts` への結線（公開 `options.onChange` 発火・view⇄edit での編集無効化）と input→command 変換は **M5**（browser・edit UI）
 - `onChange` の往復契約（PlayData の version/migration を含む確定）は **M8**
 
+### 実装メモ：編集 UI（コマンド配線・入力・UI）（2026-05-16, M5）
+
+PRD 5.4 の編集操作を VSCode 流の軽量適用で実装。判断ロジックを common に寄せて
+node 単体で全網羅し、browser は薄い DOM シェルに保った。フォーメーション読込
+（5.4 の 1 項目）はロードマップ通り **M6** として分離した。
+
+**M5 で確定（common: editing・テスト済 / 209 tests・common 100%）**
+- `EditorController`（`IEditorController`・DOM 非依存）= ツール(`select`/`add-player`/`draw-line`)・選択・**ヤード空間ジェスチャ**(pointerDown/Move/Up・commitLine・cancel) を受け、適切な `ICommand` を `ICommandService` 経由で発行する唯一の入口。hit-test は M2/M3 の common を再利用
+- ドラッグ/作図中プレビューは **`getRenderModel()`**（Model スナップショット＋一時状態の純合成）で表現。これで実データ変更は **1 コマンド = onChange 1 回**（M4 契約）を保ち、見た目の追従はコマンド・履歴を汚さない。`getOverlay()` が選択強調/ハンドル位置（ヤード空間）を返し browser は描くだけ
+- **選択は「id の希望」で stale 許容**（対象が消えても自動解除せず lookup が空を返す）。これで防御分岐がすべて到達可能になり `v8 ignore` 0 件で common 100% を維持（前 M と同じ規律）。`IdFactory` は prefix ごと単調増加で衝突しない安定 id を採番（削除済み id を再利用しない＝Undo 復活と衝突しない）
+- waypoint 編集は M4 の可逆プリミティブ `SetLineWaypointsCommand` に**ハンドルのドラッグ移動**を載せた（列まるごと差し替え）。線の `end` 編集は M4 で凍結した 9 コマンドに無く、PRD 5.4 の語（「描画／waypoint 編集」）に沿って**作図やり直し（delete→draw）で代替**。waypoint の個別 add/insert と end 編集は **M9 磨き**へ
+- フィールドゾーン切替を `SetFieldZoneCommand` 経由に統一（Undo/onChange の対象に）。M1 で直接 set していた `Playmaker.setFieldZone` も結線し直した
+
+**M5 で確定（browser: 最小限・VRT なし）**
+- `CanvasSurface` を controller 駆動へ：`getRenderModel()`/`getOverlay()` を 1 フレーム合成描画＋選択 overlay（選手リング/線ハイライト/waypoint ハンドル）。`clientToYard` で px→ヤード逆変換を提供（座標規約を 1 か所に集約）
+- `PointerInput`（pointer/dblclick＝作図確定/`Esc`＝取消/`Enter`＝確定/`⌘|Ctrl+Z`＝Undo・`Shift`/`Y`＝Redo。PRD 8.1 で Undo/Redo ショートカットのみスコープ内）。`Toolbar`/`PropertyPanel` はバニラ DOM・`--playmaker-*`（`--playmaker-selection-color` 追加）
+- `playmaker.ts` = 1 セッション(Model+履歴+UI)を結線。`model.onDidChange`→`options.onChange` 発火（構築時は無発火＝再読込は edit でない）。**edit のみ UI/入力**、`view` は読み取り専用（PRD 5.5・CSS でも保険的に非表示）。`setPlayData` は Model に `setData` を足さず**セッション再構築**で対応（履歴リセット＝M4 API を尊重）
+- demo は内蔵 UI で編集＋Undo/Redo を目視、`onChange` でデータ連携を可視化
+
+**M6 / M8 / M9 へ繰り延べ**
+- フォーメーションテンプレート読込（5.4 の 1 項目）= **M6**
+- `onChange` の往復契約（version/migration 含む確定）= **M8**
+- 見た目磨き（選択強調/矢じり/ハンドル体裁）・waypoint 個別 add/remove・線 end のドラッグ編集 = **M9**
+
 ### 完了判定（PRD 7 章）
 - 機能要件（PRD 5 章）すべてが仕様通り動作
 - `common` 層の単体テストおよび統合テストが通る

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,7 +1,9 @@
 // browser 層の公開面。DOM / Canvas 依存の実装をここから export する。
-// 以降のマイルストーンで ui / input を追加する。
 
+export { PointerInput } from "./input/pointer-input.js";
 export { CanvasSurface } from "./rendering/canvas-surface.js";
 export { FieldRenderer, type FieldTheme } from "./rendering/field-renderer.js";
 export { LineRenderer, type LineTheme } from "./rendering/line-renderer.js";
 export { PlayerRenderer, type PlayerTheme } from "./rendering/player-renderer.js";
+export { PropertyPanel } from "./ui/property-panel.js";
+export { Toolbar } from "./ui/toolbar.js";

--- a/src/browser/input/pointer-input.ts
+++ b/src/browser/input/pointer-input.ts
@@ -1,0 +1,68 @@
+// Canvas のポインタ/キーボード入力を EditorController のジェスチャへ変換する。
+// 座標規約（px→ヤード）は CanvasSurface に集約し、編集判断は common 側が持つ。
+// ここは「DOM イベントを意味のある操作に翻訳する」だけの薄い層（browser・最小限）。
+
+import { Disposable, type IEditorController, toDisposable } from "../../common/index.js";
+import type { CanvasSurface } from "../rendering/canvas-surface.js";
+
+export class PointerInput extends Disposable {
+  constructor(surface: CanvasSurface, controller: IEditorController) {
+    super();
+    const canvas = surface.canvas;
+    // Esc / Enter / Undo・Redo を受け取れるようフォーカス可能にする。
+    canvas.tabIndex = 0;
+
+    const toYard = (e: PointerEvent) => surface.clientToYard(e.clientX, e.clientY);
+
+    const onPointerDown = (e: PointerEvent) => {
+      canvas.focus();
+      canvas.setPointerCapture(e.pointerId);
+      controller.pointerDown(toYard(e));
+    };
+    // draw-line のラバーバンドはボタン非押下でも追従させたいので常に渡す
+    // （interaction が無ければ controller 側で無視される）。
+    const onPointerMove = (e: PointerEvent) => controller.pointerMove(toYard(e));
+    const onPointerUp = (e: PointerEvent) => {
+      controller.pointerUp(toYard(e));
+      if (canvas.hasPointerCapture(e.pointerId)) {
+        canvas.releasePointerCapture(e.pointerId);
+      }
+    };
+    // ダブルクリック = 作図確定（最後の点を終点に）。
+    const onDoubleClick = () => controller.commitLine();
+    const onKeyDown = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (e.key === "Escape") {
+        controller.cancelInteraction();
+      } else if (e.key === "Enter") {
+        controller.commitLine();
+      } else if (mod && (e.key === "z" || e.key === "Z")) {
+        // PRD 8.1: Undo/Redo のショートカットはスコープ内（それ以外は対象外）。
+        e.preventDefault();
+        if (e.shiftKey) {
+          controller.redo();
+        } else {
+          controller.undo();
+        }
+      } else if (mod && (e.key === "y" || e.key === "Y")) {
+        e.preventDefault();
+        controller.redo();
+      }
+    };
+
+    canvas.addEventListener("pointerdown", onPointerDown);
+    canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("pointerup", onPointerUp);
+    canvas.addEventListener("dblclick", onDoubleClick);
+    canvas.addEventListener("keydown", onKeyDown);
+    this._register(
+      toDisposable(() => {
+        canvas.removeEventListener("pointerdown", onPointerDown);
+        canvas.removeEventListener("pointermove", onPointerMove);
+        canvas.removeEventListener("pointerup", onPointerUp);
+        canvas.removeEventListener("dblclick", onDoubleClick);
+        canvas.removeEventListener("keydown", onKeyDown);
+      }),
+    );
+  }
+}

--- a/src/browser/rendering/canvas-surface.ts
+++ b/src/browser/rendering/canvas-surface.ts
@@ -1,12 +1,27 @@
-import { Disposable, FieldGeometry, type PlayData, toDisposable } from "../../common/index.js";
+import {
+  Disposable,
+  type EditorOverlay,
+  FieldGeometry,
+  type FieldPosition,
+  indexPlayersById,
+  lineAnchorPoints,
+  PLAYER_RADIUS_YARDS,
+  type PlayData,
+  sampleLinePath,
+  toDisposable,
+  WAYPOINT_HANDLE_RADIUS_YARDS,
+} from "../../common/index.js";
 import { FieldRenderer, type FieldTheme } from "./field-renderer.js";
 import { LineRenderer, type LineTheme } from "./line-renderer.js";
 import { PlayerRenderer, type PlayerTheme } from "./player-renderer.js";
 
+const EMPTY_OVERLAY: EditorOverlay = { waypointHandles: [] };
+
 /**
  * Canvas のライフサイクル・解像度（DPR）・リサイズを管理し、
- * 現在の PlayData（ゾーン + 線 + 選手）を 1 フレームへ合成描画する土台。
- * Model は Playmaker が専有し、ここは渡された PlayData を描くだけ（Model–View 分離）。
+ * 「描画モデル + 選択 overlay」を 1 フレームへ合成描画する土台。
+ * 何を描くか（プレビュー合成・選択強調）の判断は common(EditorController) が持ち、
+ * ここは渡されたシーンを描くだけ（Model–View 分離）。
  */
 export class CanvasSurface extends Disposable {
   readonly canvas: HTMLCanvasElement;
@@ -15,6 +30,9 @@ export class CanvasSurface extends Disposable {
   private readonly lineRenderer = new LineRenderer();
   private readonly playerRenderer = new PlayerRenderer();
   private data: PlayData;
+  private overlay: EditorOverlay = EMPTY_OVERLAY;
+  // 直近 render で確定する。constructor 末尾の resize()→render() で必ず初期化される。
+  private geometry!: FieldGeometry;
 
   constructor(parent: HTMLElement, data: PlayData) {
     super();
@@ -38,10 +56,20 @@ export class CanvasSurface extends Disposable {
     this.resize();
   }
 
-  /** 描画対象の PlayData を差し替えて再描画する（ゾーン切替・選手投入の双方）。 */
-  setData(data: PlayData): void {
+  /** 描画モデルと選択 overlay を差し替えて再描画する（編集のたびに呼ばれる）。 */
+  setScene(data: PlayData, overlay: EditorOverlay): void {
     this.data = data;
+    this.overlay = overlay;
     this.render();
+  }
+
+  /**
+   * Canvas クライアント座標（マウスイベントの clientX/Y）をヤード空間へ逆変換する。
+   * 入力 → コマンドの土台。geometry が唯一の座標規約なのでここを通す。
+   */
+  clientToYard(clientX: number, clientY: number): FieldPosition {
+    const rect = this.canvas.getBoundingClientRect();
+    return this.geometry.fromCanvas({ x: clientX - rect.left, y: clientY - rect.top });
   }
 
   /** コンテナサイズと DPR に合わせてバックバッファを再構成し再描画する。 */
@@ -57,25 +85,83 @@ export class CanvasSurface extends Disposable {
 
   private render(): void {
     const { clientWidth, clientHeight } = this.canvas.parentElement ?? this.canvas;
-    const geometry = new FieldGeometry(clientWidth, clientHeight, this.data.field.zone);
-    const { field, line, player } = this.readThemes();
+    this.geometry = new FieldGeometry(clientWidth, clientHeight, this.data.field.zone);
+    // getComputedStyle はスタイル再計算を誘発しうるため 1 render = 1 回に束ねる。
+    const read = this.makeReader();
+    const { field, line, player } = this.readThemes(read);
     // 線は選手の下に敷く＝起点（選手位置）がマーカーで隠れ、線の根元が綺麗に見える。
-    this.fieldRenderer.draw(this.ctx, geometry, field);
-    this.lineRenderer.draw(this.ctx, geometry, this.data.lines, this.data.players, line);
-    this.playerRenderer.draw(this.ctx, geometry, this.data.players, player);
+    this.fieldRenderer.draw(this.ctx, this.geometry, field);
+    this.lineRenderer.draw(this.ctx, this.geometry, this.data.lines, this.data.players, line);
+    this.playerRenderer.draw(this.ctx, this.geometry, this.data.players, player);
+    this.drawOverlay(read("--playmaker-selection-color", "#ff9800"));
+  }
+
+  /**
+   * 選択強調と waypoint ハンドルを最前面に描く（編集中の視認用）。
+   * 位置計算は common のジオメトリに委譲し、ここは色と図形を置くだけ。
+   */
+  private drawOverlay(accent: string): void {
+    const { selectedPlayerId, selectedLineId, waypointHandles } = this.overlay;
+
+    if (selectedPlayerId !== undefined) {
+      const player = this.data.players.find((p) => p.id === selectedPlayerId);
+      if (player) {
+        const { x, y } = this.geometry.toCanvas(
+          player.position.lateralYard,
+          player.position.absoluteYard,
+        );
+        const r = PLAYER_RADIUS_YARDS * this.geometry.scale + 4;
+        this.ctx.beginPath();
+        this.ctx.arc(x, y, r, 0, Math.PI * 2);
+        this.ctx.strokeStyle = accent;
+        this.ctx.lineWidth = 2;
+        this.ctx.stroke();
+      }
+    }
+
+    if (selectedLineId !== undefined) {
+      const line = this.data.lines.find((l) => l.id === selectedLineId);
+      const anchors = line
+        ? lineAnchorPoints(line, indexPlayersById(this.data.players))
+        : undefined;
+      if (line && anchors) {
+        const polyline = sampleLinePath(anchors, line.interpolation);
+        this.ctx.beginPath();
+        polyline.forEach((pt, i) => {
+          const { x, y } = this.geometry.toCanvas(pt.lateralYard, pt.absoluteYard);
+          if (i === 0) {
+            this.ctx.moveTo(x, y);
+          } else {
+            this.ctx.lineTo(x, y);
+          }
+        });
+        this.ctx.strokeStyle = accent;
+        this.ctx.lineWidth = 6;
+        this.ctx.globalAlpha = 0.35;
+        this.ctx.stroke();
+        this.ctx.globalAlpha = 1;
+      }
+    }
+
+    const handleSize = WAYPOINT_HANDLE_RADIUS_YARDS * this.geometry.scale;
+    for (const wp of waypointHandles) {
+      const { x, y } = this.geometry.toCanvas(wp.lateralYard, wp.absoluteYard);
+      this.ctx.beginPath();
+      this.ctx.rect(x - handleSize, y - handleSize, handleSize * 2, handleSize * 2);
+      this.ctx.fillStyle = accent;
+      this.ctx.fill();
+    }
   }
 
   /**
    * 配色は親要素（.playmaker-root）の CSS 変数から読む。
    * 商用ソフトが --playmaker-* を上書きすれば描画色も追従する（PRD 6.5）。
    */
-  private readThemes(): { field: FieldTheme; line: LineTheme; player: PlayerTheme } {
-    const host = this.canvas.parentElement;
-    const styles = host ? getComputedStyle(host) : null;
-    const read = (name: string, fallback: string): string => {
-      const v = styles?.getPropertyValue(name).trim();
-      return v ? v : fallback;
-    };
+  private readThemes(read: (name: string, fallback: string) => string): {
+    field: FieldTheme;
+    line: LineTheme;
+    player: PlayerTheme;
+  } {
     return {
       field: {
         fieldColor: read("--playmaker-field-bg", "#2e7d32"),
@@ -92,6 +178,15 @@ export class CanvasSurface extends Disposable {
         strokeColor: read("--playmaker-player-stroke", "rgba(255, 255, 255, 0.9)"),
         labelColor: read("--playmaker-player-label-color", "#ffffff"),
       },
+    };
+  }
+
+  private makeReader(): (name: string, fallback: string) => string {
+    const host = this.canvas.parentElement;
+    const styles = host ? getComputedStyle(host) : null;
+    return (name, fallback) => {
+      const v = styles?.getPropertyValue(name).trim();
+      return v ? v : fallback;
     };
   }
 }

--- a/src/browser/ui/property-panel.ts
+++ b/src/browser/ui/property-panel.ts
@@ -1,0 +1,151 @@
+// プロパティパネル（PRD 5.4: 選手=ラベル/形状/色、線=種別/補間/色/太さ）。
+// バニラ DOM・--playmaker-* テーマ。選択が変わるたびに中身を作り直す
+// （DOM が小さく、編集はコマンド確定時に走るので作り直しても支障ない）。
+
+import {
+  Disposable,
+  type IEditorController,
+  type LineInterpolation,
+  type LineKind,
+  type PlayerShape,
+  toDisposable,
+} from "../../common/index.js";
+
+const SHAPES: PlayerShape[] = ["circle", "square", "triangle", "diamond", "pentagon", "hexagon"];
+const KINDS: LineKind[] = ["route", "block", "motion"];
+const INTERPOLATIONS: LineInterpolation[] = ["straight", "bezier"];
+
+/** color input は hex のみ受け付けるため、非 hex は既定にフォールバックする。 */
+function toHex(value: string | undefined, fallback: string): string {
+  return value !== undefined && /^#[0-9a-fA-F]{6}$/.test(value) ? value : fallback;
+}
+
+export class PropertyPanel extends Disposable {
+  readonly element: HTMLElement;
+  // 直近に描いた内容のキー。選択や確定値が変わらない限り再構築しない
+  // （ドラッグ中の onDidChange 連打で DOM 破棄＝入力フォーカス喪失を防ぐ）。
+  private lastKey: string | null = null;
+
+  constructor(parent: HTMLElement, controller: IEditorController) {
+    super();
+    this.element = document.createElement("div");
+    this.element.className = "playmaker-panel";
+
+    parent.appendChild(this.element);
+    this._register(toDisposable(() => this.element.remove()));
+    this._register(controller.onDidChange(() => this.rebuild(controller)));
+    this.rebuild(controller);
+  }
+
+  private rebuild(controller: IEditorController): void {
+    const player = controller.getSelectedPlayer();
+    const line = controller.getSelectedLine();
+    // 確定済みプロパティのスナップショットでキー化＝ドラッグの transient 連打では不変。
+    const key =
+      player !== undefined
+        ? `p:${JSON.stringify(player)}`
+        : line !== undefined
+          ? `l:${JSON.stringify(line)}`
+          : "none";
+    if (key === this.lastKey) {
+      return;
+    }
+    this.lastKey = key;
+
+    this.element.replaceChildren();
+    if (player !== undefined) {
+      this.addTitle("選手");
+      this.addText("ラベル", player.label, (v) => controller.updateSelectedPlayer({ label: v }));
+      this.addSelect("形状", SHAPES, player.shape, (v) =>
+        controller.updateSelectedPlayer({ shape: v }),
+      );
+      this.addColor("色", player.color, (v) => controller.updateSelectedPlayer({ color: v }));
+      return;
+    }
+    if (line !== undefined) {
+      this.addTitle("線");
+      this.addSelect("種別", KINDS, line.kind, (v) => controller.updateSelectedLine({ kind: v }));
+      this.addSelect("補間", INTERPOLATIONS, line.interpolation, (v) =>
+        controller.updateSelectedLine({ interpolation: v }),
+      );
+      this.addColor("色", line.color, (v) => controller.updateSelectedLine({ color: v }));
+      this.addNumber("太さ", line.thickness ?? 2, (v) =>
+        controller.updateSelectedLine({ thickness: v }),
+      );
+      return;
+    }
+    const hint = document.createElement("p");
+    hint.className = "playmaker-panel__hint";
+    hint.textContent = "対象を選択するとプロパティを編集できます";
+    this.element.appendChild(hint);
+  }
+
+  private addTitle(text: string): void {
+    const h = document.createElement("h2");
+    h.className = "playmaker-panel__title";
+    h.textContent = text;
+    this.element.appendChild(h);
+  }
+
+  private addRow(labelText: string, control: HTMLElement): void {
+    const row = document.createElement("label");
+    row.className = "playmaker-panel__row";
+    const span = document.createElement("span");
+    span.textContent = labelText;
+    row.append(span, control);
+    this.element.appendChild(row);
+  }
+
+  private addText(labelText: string, value: string, onChange: (v: string) => void): void {
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = value;
+    input.addEventListener("change", () => onChange(input.value));
+    this.addRow(labelText, input);
+  }
+
+  private addNumber(labelText: string, value: number, onChange: (v: number) => void): void {
+    const input = document.createElement("input");
+    input.type = "number";
+    input.min = "1";
+    input.step = "0.5";
+    input.value = String(value);
+    input.addEventListener("change", () => {
+      const n = Number(input.value);
+      if (Number.isFinite(n) && n > 0) {
+        onChange(n);
+      }
+    });
+    this.addRow(labelText, input);
+  }
+
+  private addColor(
+    labelText: string,
+    value: string | undefined,
+    onChange: (v: string) => void,
+  ): void {
+    const input = document.createElement("input");
+    input.type = "color";
+    input.value = toHex(value, "#1565c0");
+    input.addEventListener("change", () => onChange(input.value));
+    this.addRow(labelText, input);
+  }
+
+  private addSelect<T extends string>(
+    labelText: string,
+    options: readonly T[],
+    value: T,
+    onChange: (v: T) => void,
+  ): void {
+    const select = document.createElement("select");
+    for (const opt of options) {
+      const o = document.createElement("option");
+      o.value = opt;
+      o.textContent = opt;
+      o.selected = opt === value;
+      select.appendChild(o);
+    }
+    select.addEventListener("change", () => onChange(select.value as T));
+    this.addRow(labelText, select);
+  }
+}

--- a/src/browser/ui/toolbar.ts
+++ b/src/browser/ui/toolbar.ts
@@ -1,0 +1,94 @@
+// 編集ツールバー（PRD 5.4 / 6.5）。バニラ DOM・--playmaker-* テーマ。
+// 状態は EditorController が真実源で、ここは「ボタン → アクション」と
+// 「onDidChange → 見た目同期」を繋ぐだけ（フレームワーク非依存・組み込み容易）。
+
+import {
+  Disposable,
+  type EditorTool,
+  type FieldZone,
+  type IEditorController,
+  toDisposable,
+} from "../../common/index.js";
+
+const TOOLS: { tool: EditorTool; label: string }[] = [
+  { tool: "select", label: "選択" },
+  { tool: "add-player", label: "選手を追加" },
+  { tool: "draw-line", label: "線を描く" },
+];
+
+const ZONES: { zone: FieldZone; label: string }[] = [
+  { zone: "own-redzone", label: "自陣RZ" },
+  { zone: "middle", label: "中央" },
+  { zone: "redzone", label: "相手RZ" },
+];
+
+export class Toolbar extends Disposable {
+  readonly element: HTMLElement;
+  private readonly toolButtons = new Map<EditorTool, HTMLButtonElement>();
+  private readonly zoneButtons = new Map<FieldZone, HTMLButtonElement>();
+  private readonly undoButton: HTMLButtonElement;
+  private readonly redoButton: HTMLButtonElement;
+  private readonly deleteButton: HTMLButtonElement;
+  private readonly commitButton: HTMLButtonElement;
+  private readonly cancelButton: HTMLButtonElement;
+
+  constructor(parent: HTMLElement, controller: IEditorController) {
+    super();
+    this.element = document.createElement("div");
+    this.element.className = "playmaker-toolbar";
+
+    for (const { tool, label } of TOOLS) {
+      const btn = this.addButton(label, () => controller.setTool(tool));
+      this.toolButtons.set(tool, btn);
+    }
+    this.addSeparator();
+    this.undoButton = this.addButton("元に戻す", () => controller.undo());
+    this.redoButton = this.addButton("やり直す", () => controller.redo());
+    this.deleteButton = this.addButton("削除", () => controller.deleteSelection());
+    this.addSeparator();
+    for (const { zone, label } of ZONES) {
+      const btn = this.addButton(label, () => controller.setFieldZone(zone));
+      this.zoneButtons.set(zone, btn);
+    }
+    this.addSeparator();
+    this.commitButton = this.addButton("線を確定", () => controller.commitLine());
+    this.cancelButton = this.addButton("取消", () => controller.cancelInteraction());
+
+    parent.appendChild(this.element);
+    this._register(toDisposable(() => this.element.remove()));
+    this._register(controller.onDidChange(() => this.sync(controller)));
+    this.sync(controller);
+  }
+
+  private addButton(label: string, onClick: () => void): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = label;
+    button.className = "playmaker-toolbar__button";
+    button.addEventListener("click", onClick);
+    this.element.appendChild(button);
+    return button;
+  }
+
+  private addSeparator(): void {
+    const sep = document.createElement("span");
+    sep.className = "playmaker-toolbar__sep";
+    sep.setAttribute("aria-hidden", "true");
+    this.element.appendChild(sep);
+  }
+
+  private sync(controller: IEditorController): void {
+    const state = controller.getViewState();
+    for (const [tool, btn] of this.toolButtons) {
+      btn.setAttribute("aria-pressed", String(tool === state.tool));
+    }
+    for (const [zone, btn] of this.zoneButtons) {
+      btn.setAttribute("aria-pressed", String(zone === state.fieldZone));
+    }
+    this.undoButton.disabled = !state.canUndo;
+    this.redoButton.disabled = !state.canRedo;
+    this.deleteButton.disabled = state.selection === null;
+    this.commitButton.disabled = !state.drawing;
+    this.cancelButton.disabled = !state.drawing;
+  }
+}

--- a/src/common/editing/editor-controller.test.ts
+++ b/src/common/editing/editor-controller.test.ts
@@ -1,0 +1,636 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CommandService } from "../commands/command-service.js";
+import { RemoveLineCommand, RemovePlayerCommand } from "../index.js";
+import type { PlayData } from "../model/play-data.js";
+import { PlayModel } from "../model/play-model.js";
+import { UndoRedoService } from "../undoRedo/undo-redo-service.js";
+import { EditorController } from "./editor-controller.js";
+import { IdFactory } from "./id-factory.js";
+
+function initialData(): PlayData {
+  return {
+    version: 1,
+    field: { zone: "middle" },
+    players: [
+      { id: "p-a", position: { lateralYard: 10, absoluteYard: 50 }, shape: "circle", label: "A" },
+      { id: "p-b", position: { lateralYard: 20, absoluteYard: 50 }, shape: "square", label: "B" },
+    ],
+    lines: [
+      {
+        id: "l-1",
+        kind: "route",
+        startPlayerId: "p-a",
+        waypoints: [{ lateralYard: 15, absoluteYard: 52 }],
+        end: { lateralYard: 25, absoluteYard: 55 },
+        interpolation: "straight",
+      },
+    ],
+  };
+}
+
+function setup(data: PlayData = initialData()) {
+  const model = new PlayModel(data);
+  const undoRedo = new UndoRedoService(model);
+  const commands = new CommandService(model, undoRedo);
+  const ids = new IdFactory();
+  const controller = new EditorController(model, commands, undoRedo, ids);
+  const changes = vi.fn();
+  controller.onDidChange(changes);
+  return { model, undoRedo, commands, ids, controller, changes };
+}
+
+describe("EditorController: 初期状態", () => {
+  it("既定は select ツール・無選択・履歴空", () => {
+    const { controller } = setup();
+
+    expect(controller.getTool()).toBe("select");
+    expect(controller.getSelection()).toBeNull();
+    expect(controller.getViewState()).toEqual({
+      tool: "select",
+      selection: null,
+      canUndo: false,
+      canRedo: false,
+      fieldZone: "middle",
+      drawing: false,
+    });
+    expect(controller.getOverlay()).toEqual({ waypointHandles: [] });
+    expect(controller.getSelectedPlayer()).toBeUndefined();
+    expect(controller.getSelectedLine()).toBeUndefined();
+  });
+
+  it("interaction が無ければ getRenderModel は Model のスナップショットそのまま", () => {
+    const { controller, model } = setup();
+
+    const rendered = controller.getRenderModel();
+
+    expect(rendered).toEqual(model.getData());
+    // 返り値を書き換えても Model に波及しない（スナップショット）。
+    rendered.players.push({
+      id: "x",
+      position: { lateralYard: 0, absoluteYard: 0 },
+      shape: "circle",
+      label: "",
+    });
+    expect(model.getData().players).toHaveLength(2);
+  });
+});
+
+describe("EditorController: ツール切替", () => {
+  it("同じツールへの切替は何もしない", () => {
+    const { controller, changes } = setup();
+
+    controller.setTool("select");
+
+    expect(controller.getTool()).toBe("select");
+    expect(changes).not.toHaveBeenCalled();
+  });
+
+  it("別ツールへ切替えると発火し作図途中を破棄する", () => {
+    const { controller, changes } = setup();
+    controller.setTool("draw-line");
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a から作図開始
+    expect(controller.getViewState().drawing).toBe(true);
+    changes.mockClear();
+
+    controller.setTool("select");
+
+    expect(controller.getTool()).toBe("select");
+    expect(controller.getViewState().drawing).toBe(false);
+    expect(changes).toHaveBeenCalledOnce();
+  });
+});
+
+describe("EditorController: 選手の追加（add-player）", () => {
+  it("空白クリックで選手を追加し、それを選択する", () => {
+    const { controller, model } = setup({
+      version: 1,
+      field: { zone: "middle" },
+      players: [],
+      lines: [],
+    });
+    controller.setTool("add-player");
+
+    controller.pointerDown({ lateralYard: 30, absoluteYard: 45 });
+
+    const players = model.getData().players;
+    expect(players).toHaveLength(1);
+    expect(players[0]).toMatchObject({
+      id: "player-1",
+      position: { lateralYard: 30, absoluteYard: 45 },
+      shape: "circle",
+      label: "",
+    });
+    expect(controller.getSelection()).toEqual({ kind: "player", id: "player-1" });
+    expect(controller.getViewState().canUndo).toBe(true);
+  });
+});
+
+describe("EditorController: 線の作図（draw-line）", () => {
+  it("選手以外で始めようとしても無視する（起点は必ず選手）", () => {
+    const { controller, changes } = setup();
+    controller.setTool("draw-line");
+    changes.mockClear(); // setTool 自体の発火を除外
+
+    controller.pointerDown({ lateralYard: 40, absoluteYard: 40 });
+
+    expect(controller.getViewState().drawing).toBe(false);
+    expect(changes).not.toHaveBeenCalled();
+  });
+
+  it("選手から開始するとプレビュー線が getRenderModel に現れカーソルに追従する", () => {
+    const { controller } = setup();
+    controller.setTool("draw-line");
+
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a
+    expect(controller.getViewState().drawing).toBe(true);
+    let rendered = controller.getRenderModel();
+    expect(rendered.lines).toHaveLength(2);
+    expect(rendered.lines[1]).toMatchObject({
+      startPlayerId: "p-a",
+      waypoints: [],
+      end: { lateralYard: 10, absoluteYard: 50 },
+    });
+
+    controller.pointerMove({ lateralYard: 12, absoluteYard: 58 });
+    rendered = controller.getRenderModel();
+    expect(rendered.lines[1]?.end).toEqual({ lateralYard: 12, absoluteYard: 58 });
+
+    controller.pointerDown({ lateralYard: 12, absoluteYard: 58 }); // 中継点を打つ
+    rendered = controller.getRenderModel();
+    expect(rendered.lines[1]?.waypoints).toEqual([{ lateralYard: 12, absoluteYard: 58 }]);
+  });
+
+  it("確定すると最後の点を終点、手前を waypoint として線を追加し選択する", () => {
+    const { controller, model } = setup();
+    controller.setTool("draw-line");
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a
+    controller.pointerDown({ lateralYard: 12, absoluteYard: 55 }); // waypoint
+    controller.pointerDown({ lateralYard: 18, absoluteYard: 60 }); // end
+
+    controller.commitLine();
+
+    const lines = model.getData().lines;
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toMatchObject({
+      id: "line-1",
+      kind: "route",
+      startPlayerId: "p-a",
+      waypoints: [{ lateralYard: 12, absoluteYard: 55 }],
+      end: { lateralYard: 18, absoluteYard: 60 },
+      interpolation: "straight",
+    });
+    expect(controller.getSelection()).toEqual({ kind: "line", id: "line-1" });
+    expect(controller.getViewState().drawing).toBe(false);
+  });
+
+  it("点が無いまま確定すると線を追加せず作図を破棄する", () => {
+    const { controller, model, changes } = setup();
+    controller.setTool("draw-line");
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // 開始のみ（点なし）
+    changes.mockClear();
+
+    controller.commitLine();
+
+    expect(model.getData().lines).toHaveLength(1);
+    expect(controller.getViewState().drawing).toBe(false);
+    expect(changes).toHaveBeenCalledOnce();
+  });
+
+  it("起点選手が作図中に消えたら確定しても線を追加しない", () => {
+    const { controller, model, commands } = setup();
+    controller.setTool("draw-line");
+    controller.pointerDown({ lateralYard: 20, absoluteYard: 50 }); // p-b から
+    controller.pointerDown({ lateralYard: 22, absoluteYard: 58 }); // 点あり
+    commands.execute(new RemovePlayerCommand("p-b")); // 起点が消える
+
+    controller.commitLine();
+
+    expect(model.getData().lines).toHaveLength(1); // l-1 のみ（p-b 起点線は無かった）
+  });
+
+  it("draw-line 中でないときの commitLine は何もしない", () => {
+    const { controller } = setup();
+
+    expect(() => controller.commitLine()).not.toThrow();
+
+    // select ツールでドラッグ中（draw-line でない interaction）でも何もしない。
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a を掴む
+    expect(() => controller.commitLine()).not.toThrow();
+  });
+
+  it("cancelInteraction で作図を破棄する／途中でなければ無反応", () => {
+    const { controller, changes } = setup();
+    controller.cancelInteraction(); // 何も無い → 無反応
+    expect(changes).not.toHaveBeenCalled();
+
+    controller.setTool("draw-line");
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 });
+    changes.mockClear();
+    controller.cancelInteraction();
+
+    expect(controller.getViewState().drawing).toBe(false);
+    expect(changes).toHaveBeenCalledOnce();
+  });
+});
+
+describe("EditorController: 選択と選手ドラッグ（select）", () => {
+  it("選手クリックで選択、動かさず離せばコマンドは出ない", () => {
+    const { controller, undoRedo } = setup();
+
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a 中心
+    expect(controller.getSelection()).toEqual({ kind: "player", id: "p-a" });
+    controller.pointerUp({ lateralYard: 10, absoluteYard: 50 });
+
+    expect(undoRedo.canUndo).toBe(false);
+    expect(controller.getSelectedPlayer()).toMatchObject({ id: "p-a" });
+  });
+
+  it("ドラッグするとプレビューが追従し、離すと MovePlayerCommand を実行する", () => {
+    const { controller, model } = setup();
+
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a（offset 0）
+    controller.pointerMove({ lateralYard: 14, absoluteYard: 53 });
+    const preview = controller.getRenderModel().players.find((p) => p.id === "p-a");
+    expect(preview?.position).toEqual({ lateralYard: 14, absoluteYard: 53 });
+
+    controller.pointerUp({ lateralYard: 14, absoluteYard: 53 });
+
+    expect(model.findPlayer("p-a")?.position).toEqual({ lateralYard: 14, absoluteYard: 53 });
+    expect(model.getData().lines[0]?.startPlayerId).toBe("p-a"); // 線は起点選手に追従
+  });
+
+  it("ドラッグ中に選手が消えたら離してもコマンドを出さない", () => {
+    const { controller, model, commands } = setup();
+    controller.pointerDown({ lateralYard: 20, absoluteYard: 50 }); // p-b
+    commands.execute(new RemovePlayerCommand("p-b"));
+
+    controller.pointerMove({ lateralYard: 24, absoluteYard: 54 });
+    expect(() => controller.pointerUp({ lateralYard: 24, absoluteYard: 54 })).not.toThrow();
+
+    expect(model.getData().players.some((p) => p.id === "p-b")).toBe(false);
+  });
+
+  it("pointerMove は interaction が無ければ無反応、pointerUp も同様", () => {
+    const { controller, changes } = setup();
+
+    controller.pointerMove({ lateralYard: 1, absoluteYard: 1 });
+    controller.pointerUp({ lateralYard: 1, absoluteYard: 1 });
+
+    expect(changes).not.toHaveBeenCalled();
+  });
+
+  it("pointerUp は作図中（draw-line）には何もしない", () => {
+    const { controller, model } = setup();
+    controller.setTool("draw-line");
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 });
+
+    controller.pointerUp({ lateralYard: 10, absoluteYard: 50 });
+
+    expect(controller.getViewState().drawing).toBe(true); // まだ作図継続
+    expect(model.getData().lines).toHaveLength(1);
+  });
+
+  it("空白クリックで選択解除、無選択での空白クリックは発火しない", () => {
+    const { controller, changes } = setup();
+    // 無選択で空白 → setSelection(null) は同値で発火しない。
+    controller.pointerDown({ lateralYard: 45, absoluteYard: 40 });
+    controller.pointerUp({ lateralYard: 45, absoluteYard: 40 });
+    expect(changes).not.toHaveBeenCalled();
+
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a 選択
+    controller.pointerUp({ lateralYard: 10, absoluteYard: 50 });
+    controller.pointerDown({ lateralYard: 45, absoluteYard: 40 }); // 空白 → 解除
+    expect(controller.getSelection()).toBeNull();
+  });
+
+  it("線をクリックすると線が選択される", () => {
+    const { controller } = setup();
+
+    controller.pointerDown({ lateralYard: 15, absoluteYard: 52 }); // l-1 の waypoint 上＝線上
+
+    expect(controller.getSelection()).toEqual({ kind: "line", id: "l-1" });
+  });
+
+  it("同じ選手の再選択や別対象選択で sameSelection を網羅する", () => {
+    const { controller } = setup();
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a
+    controller.pointerUp({ lateralYard: 10, absoluteYard: 50 });
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // 同じ p-a（同値）
+    controller.pointerUp({ lateralYard: 10, absoluteYard: 50 });
+    expect(controller.getSelection()).toEqual({ kind: "player", id: "p-a" });
+
+    controller.pointerDown({ lateralYard: 20, absoluteYard: 50 }); // p-b（別 id）
+    controller.pointerUp({ lateralYard: 20, absoluteYard: 50 });
+    expect(controller.getSelection()).toEqual({ kind: "player", id: "p-b" });
+
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 終点付近（別 kind）
+    expect(controller.getSelection()).toEqual({ kind: "line", id: "l-1" });
+  });
+});
+
+describe("EditorController: waypoint 編集", () => {
+  it("選択中の線の waypoint をドラッグして SetLineWaypointsCommand を実行する", () => {
+    const { controller, model } = setup();
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 を選択（終点側）
+    expect(controller.getSelection()).toEqual({ kind: "line", id: "l-1" });
+
+    controller.pointerDown({ lateralYard: 15, absoluteYard: 52 }); // waypoint 0 を掴む
+    controller.pointerMove({ lateralYard: 16, absoluteYard: 54 });
+    const handles = controller.getOverlay().waypointHandles;
+    expect(handles).toEqual([{ lateralYard: 16, absoluteYard: 54 }]);
+    controller.pointerUp({ lateralYard: 16, absoluteYard: 54 });
+
+    expect(model.findLine("l-1")?.waypoints).toEqual([{ lateralYard: 16, absoluteYard: 54 }]);
+  });
+
+  it("waypoint を掴んで動かさず離せばコマンドを出さない", () => {
+    const { controller, undoRedo } = setup();
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 選択
+    controller.pointerDown({ lateralYard: 15, absoluteYard: 52 }); // waypoint
+    controller.pointerUp({ lateralYard: 15, absoluteYard: 52 });
+
+    expect(undoRedo.canUndo).toBe(false);
+  });
+
+  it("waypoint ドラッグ中に線が消えたら離してもコマンドを出さない", () => {
+    const { controller, commands, model } = setup();
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 選択
+    controller.pointerDown({ lateralYard: 15, absoluteYard: 52 }); // waypoint 掴む
+    commands.execute(new RemoveLineCommand("l-1"));
+
+    controller.pointerMove({ lateralYard: 16, absoluteYard: 54 });
+    expect(() => controller.pointerUp({ lateralYard: 16, absoluteYard: 54 })).not.toThrow();
+    expect(model.getData().lines).toHaveLength(0);
+  });
+
+  it("選択線が消えていれば waypoint 掴みをスキップして通常選択へ進む", () => {
+    const { controller, commands } = setup();
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 選択
+    commands.execute(new RemoveLineCommand("l-1")); // 選択は stale のまま
+
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a を選べる
+
+    expect(controller.getSelection()).toEqual({ kind: "player", id: "p-a" });
+  });
+
+  it("選択線の waypoint から外れた点では掴まず通常選択にフォールバックする", () => {
+    const { controller } = setup();
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 選択
+    controller.pointerUp({ lateralYard: 25, absoluteYard: 55 });
+
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // waypoint から遠い→ p-a
+
+    expect(controller.getSelection()).toEqual({ kind: "player", id: "p-a" });
+  });
+
+  it("waypoint が無い線を選択中はハンドル走査が空で素通りする", () => {
+    const { controller } = setup({
+      version: 1,
+      field: { zone: "middle" },
+      players: [
+        { id: "p-a", position: { lateralYard: 10, absoluteYard: 50 }, shape: "circle", label: "A" },
+      ],
+      lines: [
+        {
+          id: "l-0",
+          kind: "block",
+          startPlayerId: "p-a",
+          waypoints: [],
+          end: { lateralYard: 18, absoluteYard: 50 },
+          interpolation: "straight",
+        },
+      ],
+    });
+    controller.pointerDown({ lateralYard: 14, absoluteYard: 50 }); // l-0 上を選択
+    expect(controller.getSelection()).toEqual({ kind: "line", id: "l-0" });
+
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a へ
+
+    expect(controller.getSelection()).toEqual({ kind: "player", id: "p-a" });
+  });
+
+  it("複数 waypoint・複数線でドラッグ中の 1 点だけが overlay/getRenderModel に反映される", () => {
+    const { controller, model } = setup({
+      version: 1,
+      field: { zone: "middle" },
+      players: [
+        { id: "p-a", position: { lateralYard: 10, absoluteYard: 50 }, shape: "circle", label: "A" },
+      ],
+      lines: [
+        {
+          id: "l-2",
+          kind: "route",
+          startPlayerId: "p-a",
+          waypoints: [
+            { lateralYard: 14, absoluteYard: 52 },
+            { lateralYard: 18, absoluteYard: 56 },
+          ],
+          end: { lateralYard: 22, absoluteYard: 60 },
+          interpolation: "straight",
+        },
+        {
+          id: "l-3",
+          kind: "block",
+          startPlayerId: "p-a",
+          waypoints: [{ lateralYard: 8, absoluteYard: 48 }],
+          end: { lateralYard: 5, absoluteYard: 45 },
+          interpolation: "straight",
+        },
+      ],
+    });
+    controller.pointerDown({ lateralYard: 22, absoluteYard: 60 }); // l-2 選択
+    controller.pointerDown({ lateralYard: 14, absoluteYard: 52 }); // waypoint 0 掴む
+    controller.pointerMove({ lateralYard: 15, absoluteYard: 53 });
+
+    // ドラッグ中の点だけ current、他 waypoint・他線は不変。
+    expect(controller.getOverlay().waypointHandles).toEqual([
+      { lateralYard: 15, absoluteYard: 53 },
+      { lateralYard: 18, absoluteYard: 56 },
+    ]);
+    const rendered = controller.getRenderModel();
+    expect(rendered.lines.find((l) => l.id === "l-2")?.waypoints).toEqual([
+      { lateralYard: 15, absoluteYard: 53 },
+      { lateralYard: 18, absoluteYard: 56 },
+    ]);
+    expect(rendered.lines.find((l) => l.id === "l-3")?.waypoints).toEqual([
+      { lateralYard: 8, absoluteYard: 48 },
+    ]);
+
+    // 確定すると掴んだ点だけ差し替わり、もう 1 点はそのまま残る。
+    controller.pointerUp({ lateralYard: 15, absoluteYard: 53 });
+    expect(model.findLine("l-2")?.waypoints).toEqual([
+      { lateralYard: 15, absoluteYard: 53 },
+      { lateralYard: 18, absoluteYard: 56 },
+    ]);
+  });
+});
+
+describe("EditorController: アクション", () => {
+  it("deleteSelection: 無選択では何もしない", () => {
+    const { controller, changes } = setup();
+    controller.deleteSelection();
+    expect(changes).not.toHaveBeenCalled();
+  });
+
+  it("deleteSelection: 選手を削除し従属線もカスケード除去、選択解除", () => {
+    const { controller, model } = setup();
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a
+    controller.pointerUp({ lateralYard: 10, absoluteYard: 50 });
+
+    controller.deleteSelection();
+
+    const data = model.getData();
+    expect(data.players.some((p) => p.id === "p-a")).toBe(false);
+    expect(data.lines).toHaveLength(0); // l-1 は p-a 起点でカスケード除去
+    expect(controller.getSelection()).toBeNull();
+  });
+
+  it("deleteSelection: 選手が既に消えていればコマンドを出さない", () => {
+    const { controller, commands, undoRedo } = setup();
+    controller.pointerDown({ lateralYard: 20, absoluteYard: 50 }); // p-b
+    controller.pointerUp({ lateralYard: 20, absoluteYard: 50 });
+    commands.execute(new RemovePlayerCommand("p-b"));
+    const undoCount = undoRedo.canUndo;
+
+    controller.deleteSelection();
+
+    expect(undoRedo.canUndo).toBe(undoCount);
+    expect(controller.getSelection()).toEqual({ kind: "player", id: "p-b" });
+  });
+
+  it("deleteSelection: 線を削除し選択解除", () => {
+    const { controller, model } = setup();
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1
+    controller.deleteSelection();
+
+    expect(model.getData().lines).toHaveLength(0);
+    expect(controller.getSelection()).toBeNull();
+  });
+
+  it("deleteSelection: 線が既に消えていればコマンドを出さない", () => {
+    const { controller, commands, model } = setup();
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 選択
+    commands.execute(new RemoveLineCommand("l-1"));
+
+    expect(() => controller.deleteSelection()).not.toThrow();
+    expect(model.getData().lines).toHaveLength(0);
+  });
+
+  it("updateSelectedPlayer: 選手選択時のみ反映、それ以外は無視", () => {
+    const { controller, model, commands } = setup();
+    controller.updateSelectedPlayer({ label: "Z" }); // 無選択 → 無視
+
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // 線選択
+    controller.updateSelectedPlayer({ label: "Z" }); // 線選択 → 無視
+
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a 選択
+    controller.pointerUp({ lateralYard: 10, absoluteYard: 50 });
+    controller.updateSelectedPlayer({ label: "Z", shape: "triangle", color: "#f00" });
+    expect(model.findPlayer("p-a")).toMatchObject({
+      label: "Z",
+      shape: "triangle",
+      color: "#f00",
+    });
+
+    commands.execute(new RemovePlayerCommand("p-a")); // stale 選択
+    expect(() => controller.updateSelectedPlayer({ label: "Q" })).not.toThrow();
+  });
+
+  it("updateSelectedLine: 線選択時のみ反映、それ以外は無視", () => {
+    const { controller, model, commands } = setup();
+    controller.updateSelectedLine({ kind: "block" }); // 無選択 → 無視
+
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // 選手選択
+    controller.pointerUp({ lateralYard: 10, absoluteYard: 50 });
+    controller.updateSelectedLine({ kind: "block" }); // 選手選択 → 無視
+
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 選択
+    controller.updateSelectedLine({ kind: "motion", interpolation: "bezier", thickness: 4 });
+    expect(model.findLine("l-1")).toMatchObject({
+      kind: "motion",
+      interpolation: "bezier",
+      thickness: 4,
+    });
+
+    commands.execute(new RemoveLineCommand("l-1")); // stale 選択
+    expect(() => controller.updateSelectedLine({ kind: "route" })).not.toThrow();
+  });
+
+  it("setFieldZone: 同値は無視、変更はコマンド化して undo 可能", () => {
+    const { controller, model, undoRedo } = setup();
+    controller.setFieldZone("middle"); // 同値
+    expect(undoRedo.canUndo).toBe(false);
+
+    controller.setFieldZone("redzone");
+    expect(model.getFieldZone()).toBe("redzone");
+    expect(undoRedo.canUndo).toBe(true);
+  });
+
+  it("undo / redo を委譲し履歴を行き来する", () => {
+    const { controller, model } = setup();
+    controller.setTool("add-player");
+    controller.pointerDown({ lateralYard: 5, absoluteYard: 40 });
+    expect(model.getData().players).toHaveLength(3);
+
+    controller.undo();
+    expect(model.getData().players).toHaveLength(2);
+    expect(controller.getViewState().canRedo).toBe(true);
+
+    controller.redo();
+    expect(model.getData().players).toHaveLength(3);
+    expect(controller.getViewState().canUndo).toBe(true);
+  });
+});
+
+describe("EditorController: getOverlay / getSelected*", () => {
+  it("選手選択で selectedPlayerId と選手スナップショットを返す", () => {
+    const { controller } = setup();
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 });
+    controller.pointerUp({ lateralYard: 10, absoluteYard: 50 });
+
+    expect(controller.getOverlay()).toEqual({ selectedPlayerId: "p-a", waypointHandles: [] });
+    expect(controller.getSelectedPlayer()).toMatchObject({ id: "p-a" });
+    expect(controller.getSelectedLine()).toBeUndefined();
+  });
+
+  it("線選択で selectedLineId とハンドル、消えていればハンドル空", () => {
+    const { controller, commands } = setup();
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1
+
+    expect(controller.getOverlay()).toEqual({
+      selectedLineId: "l-1",
+      waypointHandles: [{ lateralYard: 15, absoluteYard: 52 }],
+    });
+    expect(controller.getSelectedLine()).toMatchObject({ id: "l-1" });
+
+    commands.execute(new RemoveLineCommand("l-1")); // stale 選択
+    expect(controller.getOverlay()).toEqual({ selectedLineId: "l-1", waypointHandles: [] });
+    expect(controller.getSelectedLine()).toBeUndefined();
+  });
+});
+
+describe("EditorController: ライフサイクル", () => {
+  it("dispose 後は Model 変更で再描画が走らない", () => {
+    const { controller, commands, changes } = setup();
+    controller.dispose();
+    changes.mockClear();
+
+    commands.execute(new RemovePlayerCommand("p-b"));
+
+    expect(changes).not.toHaveBeenCalled();
+  });
+});
+
+describe("EditorController: 初期状態（drawing フラグ別経路）", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("作図中は viewState.drawing が true になる", () => {
+    const { controller } = setup();
+    controller.setTool("draw-line");
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 });
+
+    expect(controller.getViewState().drawing).toBe(true);
+  });
+});

--- a/src/common/editing/editor-controller.ts
+++ b/src/common/editing/editor-controller.ts
@@ -1,0 +1,535 @@
+// 編集 UI（M5）の頭脳。DOM 非依存の純ロジックなので node 単体で全網羅テストできる。
+// 役割: ツール状態・選択状態・ヤード空間ジェスチャ(pointerDown/Move/Up)を受け、
+// 適切な ICommand を ICommandService 経由で発行する（Model 直接書き換えはしない）。
+// ドラッグ/作図中のプレビューは getRenderModel()（Model スナップショット＋一時状態の
+// 純粋な合成）で表現する。これにより実データ変更は 1 コマンド = onChange 1 回を保ち
+// （M4 の契約）、見た目の追従はコマンドを汚さずに済む（Model–View 分離の徹底）。
+//
+// 選択は「id の希望」であり、対象が消えても自動解除しない（lookup 側が欠落を
+// 許容して空を返す＝stale でも無害）。これで防御分岐がすべて到達可能になり、
+// common 100% を v8 ignore 0 件で維持できる。
+
+import type { ICommandService } from "../commands/command-service.js";
+import { SetFieldZoneCommand } from "../commands/field-commands.js";
+import {
+  AddLineCommand,
+  type LinePatch,
+  RemoveLineCommand,
+  SetLineWaypointsCommand,
+  UpdateLineCommand,
+} from "../commands/line-commands.js";
+import {
+  AddPlayerCommand,
+  MovePlayerCommand,
+  type PlayerPatch,
+  RemovePlayerCommand,
+  UpdatePlayerCommand,
+} from "../commands/player-commands.js";
+import { Emitter, type Event } from "../event/emitter.js";
+import { distanceToSegment, hitTestLine, hitTestPlayer } from "../geometry/hit-test.js";
+import { Disposable } from "../lifecycle/disposable.js";
+import { DEFAULT_LINE_INTERPOLATION, DEFAULT_LINE_KIND, type Line } from "../model/line.js";
+import type { FieldZone, PlayData } from "../model/play-data.js";
+import type { IPlayModel } from "../model/play-model.js";
+import { DEFAULT_PLAYER_SHAPE, type FieldPosition, type Player } from "../model/player.js";
+import type { IUndoRedoService } from "../undoRedo/undo-redo-service.js";
+import type { IIdFactory } from "./id-factory.js";
+
+/** 編集ツール（3 種で PRD 5.4 の操作を賄う）。 */
+export type EditorTool = "select" | "add-player" | "draw-line";
+
+/** 現在の選択対象。プロパティパネル・削除・waypoint 編集の対象を決める。 */
+export type EditorSelection =
+  | { readonly kind: "player"; readonly id: string }
+  | { readonly kind: "line"; readonly id: string }
+  | null;
+
+/** 選択中の線の waypoint をドラッグでき、その当たり半径（ヤード）。 */
+export const WAYPOINT_HANDLE_RADIUS_YARDS = 0.9;
+
+/** プレビュー専用の合成線 id。Model には決して入らない（getRenderModel の中だけ）。 */
+const DRAFT_LINE_ID = "__playmaker_draft_line__";
+
+/**
+ * View（CanvasSurface）が選択ハイライト/ハンドルを描くための最小情報（ヤード空間）。
+ * 「どこを強調するか」の計算は common 側に閉じ、browser は描くだけにする。
+ */
+export interface EditorOverlay {
+  selectedPlayerId?: string;
+  selectedLineId?: string;
+  /** 選択中の線の waypoint ハンドル位置（ドラッグ対象）。それ以外は空配列。 */
+  waypointHandles: FieldPosition[];
+}
+
+/** ツールバー/プロパティパネルが描画に使う集約ビュー状態。 */
+export interface EditorViewState {
+  tool: EditorTool;
+  selection: EditorSelection;
+  canUndo: boolean;
+  canRedo: boolean;
+  fieldZone: FieldZone;
+  /** 線を作図中（確定/キャンセル待ち）か。 */
+  drawing: boolean;
+}
+
+/**
+ * EditorController の公開面。browser（入力・UI）は具象でなくこの IF に依存し、
+ * テストではフェイクへ差し替えられる（インターフェース抽出）。
+ */
+export interface IEditorController {
+  readonly onDidChange: Event<void>;
+  getTool(): EditorTool;
+  setTool(tool: EditorTool): void;
+  getSelection(): EditorSelection;
+  getViewState(): EditorViewState;
+  /** 選択中の選手（複製）。選手選択でない/対象が消えていれば undefined。 */
+  getSelectedPlayer(): Player | undefined;
+  /** 選択中の線（複製）。線選択でない/対象が消えていれば undefined。 */
+  getSelectedLine(): Line | undefined;
+  getRenderModel(): PlayData;
+  getOverlay(): EditorOverlay;
+  pointerDown(pos: FieldPosition): void;
+  pointerMove(pos: FieldPosition): void;
+  pointerUp(pos: FieldPosition): void;
+  commitLine(): void;
+  cancelInteraction(): void;
+  deleteSelection(): void;
+  updateSelectedPlayer(patch: PlayerPatch): void;
+  updateSelectedLine(patch: LinePatch): void;
+  setFieldZone(zone: FieldZone): void;
+  undo(): void;
+  redo(): void;
+}
+
+/** ドラッグ/作図の一時状態。Model には載せず getRenderModel で合成表示する。 */
+type Interaction =
+  | {
+      readonly type: "drag-player";
+      readonly playerId: string;
+      readonly origin: FieldPosition;
+      readonly offsetLat: number;
+      readonly offsetAbs: number;
+      current: FieldPosition;
+    }
+  | {
+      readonly type: "drag-waypoint";
+      readonly lineId: string;
+      readonly index: number;
+      readonly origin: FieldPosition;
+      readonly offsetLat: number;
+      readonly offsetAbs: number;
+      current: FieldPosition;
+    }
+  | {
+      readonly type: "draw-line";
+      readonly startPlayerId: string;
+      readonly points: FieldPosition[];
+      cursor: FieldPosition;
+    }
+  | null;
+
+function samePosition(a: FieldPosition, b: FieldPosition): boolean {
+  return a.lateralYard === b.lateralYard && a.absoluteYard === b.absoluteYard;
+}
+
+function sameSelection(a: EditorSelection, b: EditorSelection): boolean {
+  if (a === null || b === null) {
+    return a === b;
+  }
+  return a.kind === b.kind && a.id === b.id;
+}
+
+export class EditorController extends Disposable implements IEditorController {
+  private readonly _onDidChange = this._register(new Emitter<void>());
+  readonly onDidChange = this._onDidChange.event;
+
+  private tool: EditorTool = "select";
+  private selection: EditorSelection = null;
+  private interaction: Interaction = null;
+
+  // 依存はすべて手動コンストラクタ注入（重い DI 機構は持たない＝MVP・依存最小）。
+  constructor(
+    private readonly model: IPlayModel,
+    private readonly commands: ICommandService,
+    private readonly undoRedo: IUndoRedoService,
+    private readonly ids: IIdFactory,
+  ) {
+    super();
+    // Model 変更（自分のコマンド・undo/redo・カスケード削除）のたびに再描画を促す。
+    this._register(this.model.onDidChange(() => this._onDidChange.fire()));
+  }
+
+  // --- 状態の読み取り -------------------------------------------------------
+
+  getTool(): EditorTool {
+    return this.tool;
+  }
+
+  getSelection(): EditorSelection {
+    return this.selection;
+  }
+
+  getViewState(): EditorViewState {
+    return {
+      tool: this.tool,
+      selection: this.selection,
+      canUndo: this.undoRedo.canUndo,
+      canRedo: this.undoRedo.canRedo,
+      fieldZone: this.model.getFieldZone(),
+      drawing: this.interaction?.type === "draw-line",
+    };
+  }
+
+  getSelectedPlayer(): Player | undefined {
+    const s = this.selection;
+    return s?.kind === "player" ? this.model.findPlayer(s.id) : undefined;
+  }
+
+  getSelectedLine(): Line | undefined {
+    const s = this.selection;
+    return s?.kind === "line" ? this.model.findLine(s.id) : undefined;
+  }
+
+  /** Model スナップショットに一時状態（ドラッグ/作図プレビュー）を合成して返す純関数。 */
+  getRenderModel(): PlayData {
+    const data = this.model.getData();
+    const i = this.interaction;
+    if (i === null) {
+      return data;
+    }
+    if (i.type === "drag-player") {
+      // 起点が選手の線は players を差し替えるだけで追従する（lineAnchorPoints 経由）。
+      return {
+        ...data,
+        players: data.players.map((p) =>
+          p.id === i.playerId ? { ...p, position: { ...i.current } } : p,
+        ),
+      };
+    }
+    if (i.type === "drag-waypoint") {
+      return {
+        ...data,
+        lines: data.lines.map((l) =>
+          l.id === i.lineId
+            ? {
+                ...l,
+                waypoints: l.waypoints.map((w, idx) => (idx === i.index ? { ...i.current } : w)),
+              }
+            : l,
+        ),
+      };
+    }
+    // draw-line: 起点選手 → 既存 points → 追従カーソルを終点としたプレビュー線を足す。
+    return {
+      ...data,
+      lines: [
+        ...data.lines,
+        {
+          id: DRAFT_LINE_ID,
+          kind: DEFAULT_LINE_KIND,
+          startPlayerId: i.startPlayerId,
+          waypoints: i.points.map((p) => ({ ...p })),
+          end: { ...i.cursor },
+          interpolation: DEFAULT_LINE_INTERPOLATION,
+        },
+      ],
+    };
+  }
+
+  getOverlay(): EditorOverlay {
+    const overlay: EditorOverlay = { waypointHandles: [] };
+    const s = this.selection;
+    if (s?.kind === "player") {
+      overlay.selectedPlayerId = s.id;
+    } else if (s?.kind === "line") {
+      overlay.selectedLineId = s.id;
+      const line = this.model.findLine(s.id);
+      if (line !== undefined) {
+        const drag = this.interaction;
+        overlay.waypointHandles = line.waypoints.map((w, idx) =>
+          drag?.type === "drag-waypoint" && drag.lineId === s.id && drag.index === idx
+            ? { ...drag.current }
+            : w,
+        );
+      }
+    }
+    return overlay;
+  }
+
+  // --- ツール・選択 ---------------------------------------------------------
+
+  setTool(tool: EditorTool): void {
+    if (tool === this.tool) {
+      return;
+    }
+    this.tool = tool;
+    // ツールを切り替えたら作図/ドラッグ途中は破棄する（中途半端な状態を残さない）。
+    this.interaction = null;
+    this._onDidChange.fire();
+  }
+
+  private setSelection(next: EditorSelection): void {
+    if (sameSelection(this.selection, next)) {
+      return;
+    }
+    this.selection = next;
+    this._onDidChange.fire();
+  }
+
+  // --- ジェスチャ（ヤード空間。browser が px→ヤード変換して呼ぶ） ----------
+
+  pointerDown(pos: FieldPosition): void {
+    if (this.tool === "add-player") {
+      this.addPlayerAt(pos);
+      return;
+    }
+    if (this.tool === "draw-line") {
+      this.drawLinePointerDown(pos);
+      return;
+    }
+    this.selectPointerDown(pos);
+  }
+
+  pointerMove(pos: FieldPosition): void {
+    const i = this.interaction;
+    if (i === null) {
+      return;
+    }
+    if (i.type === "draw-line") {
+      i.cursor = { ...pos };
+    } else {
+      i.current = {
+        lateralYard: pos.lateralYard + i.offsetLat,
+        absoluteYard: pos.absoluteYard + i.offsetAbs,
+      };
+    }
+    this._onDidChange.fire();
+  }
+
+  pointerUp(pos: FieldPosition): void {
+    const i = this.interaction;
+    if (i === null || i.type === "draw-line") {
+      // draw-line はクリック（pointerDown）で点を打つ。up では何もしない。
+      return;
+    }
+    this.interaction = null;
+    const final: FieldPosition = {
+      lateralYard: pos.lateralYard + i.offsetLat,
+      absoluteYard: pos.absoluteYard + i.offsetAbs,
+    };
+    if (samePosition(final, i.origin)) {
+      // 動いていない＝ただのクリック。無駄なコマンド/onChange を出さず再描画だけ。
+      this._onDidChange.fire();
+      return;
+    }
+    if (i.type === "drag-player") {
+      if (this.model.findPlayer(i.playerId) === undefined) {
+        this._onDidChange.fire();
+        return;
+      }
+      this.commands.execute(new MovePlayerCommand(i.playerId, final));
+      return;
+    }
+    const line = this.model.findLine(i.lineId);
+    if (line === undefined) {
+      this._onDidChange.fire();
+      return;
+    }
+    const waypoints = line.waypoints.map((w, idx) => (idx === i.index ? final : w));
+    this.commands.execute(new SetLineWaypointsCommand(i.lineId, waypoints));
+  }
+
+  cancelInteraction(): void {
+    if (this.interaction === null) {
+      return;
+    }
+    this.interaction = null;
+    this._onDidChange.fire();
+  }
+
+  /** 作図中の線を確定する（最後の点を終点、手前を waypoint として AddLineCommand）。 */
+  commitLine(): void {
+    const i = this.interaction;
+    if (i === null || i.type !== "draw-line") {
+      return;
+    }
+    this.interaction = null;
+    if (i.points.length === 0) {
+      // 終点に足る点が無い＝確定できない。作図を破棄して再描画のみ。
+      this._onDidChange.fire();
+      return;
+    }
+    if (this.model.findPlayer(i.startPlayerId) === undefined) {
+      this._onDidChange.fire();
+      return;
+    }
+    const waypoints = i.points.slice(0, -1);
+    const end = i.points[i.points.length - 1] as FieldPosition;
+    const id = this.ids.next("line", this.lineIds());
+    const line: Line = {
+      id,
+      kind: DEFAULT_LINE_KIND,
+      startPlayerId: i.startPlayerId,
+      waypoints: waypoints.map((p) => ({ ...p })),
+      end: { ...end },
+      interpolation: DEFAULT_LINE_INTERPOLATION,
+    };
+    this.commands.execute(new AddLineCommand(line));
+    this.setSelection({ kind: "line", id });
+  }
+
+  // --- アクション（ツールバー/パネルから） --------------------------------
+
+  deleteSelection(): void {
+    const s = this.selection;
+    if (s === null) {
+      return;
+    }
+    if (s.kind === "player") {
+      if (this.model.findPlayer(s.id) !== undefined) {
+        this.commands.execute(new RemovePlayerCommand(s.id));
+        this.setSelection(null);
+      }
+      return;
+    }
+    if (this.model.findLine(s.id) !== undefined) {
+      this.commands.execute(new RemoveLineCommand(s.id));
+      this.setSelection(null);
+    }
+  }
+
+  updateSelectedPlayer(patch: PlayerPatch): void {
+    const s = this.selection;
+    if (s?.kind !== "player" || this.model.findPlayer(s.id) === undefined) {
+      return;
+    }
+    this.commands.execute(new UpdatePlayerCommand(s.id, patch));
+  }
+
+  updateSelectedLine(patch: LinePatch): void {
+    const s = this.selection;
+    if (s?.kind !== "line" || this.model.findLine(s.id) === undefined) {
+      return;
+    }
+    this.commands.execute(new UpdateLineCommand(s.id, patch));
+  }
+
+  setFieldZone(zone: FieldZone): void {
+    if (zone === this.model.getFieldZone()) {
+      return;
+    }
+    this.commands.execute(new SetFieldZoneCommand(zone));
+  }
+
+  undo(): void {
+    this.undoRedo.undo();
+  }
+
+  redo(): void {
+    this.undoRedo.redo();
+  }
+
+  // --- 内部 ----------------------------------------------------------------
+
+  private selectPointerDown(pos: FieldPosition): void {
+    const data = this.model.getData();
+    // 1) 選択中の線の waypoint ハンドルを最優先で掴む（選手/線と重なっても編集可能に）。
+    const s = this.selection;
+    if (s?.kind === "line") {
+      const line = data.lines.find((l) => l.id === s.id);
+      if (line !== undefined) {
+        const index = this.hitWaypoint(line, pos);
+        if (index !== undefined) {
+          const origin = line.waypoints[index] as FieldPosition;
+          this.interaction = {
+            type: "drag-waypoint",
+            lineId: line.id,
+            index,
+            origin,
+            offsetLat: origin.lateralYard - pos.lateralYard,
+            offsetAbs: origin.absoluteYard - pos.absoluteYard,
+            current: { ...origin },
+          };
+          this._onDidChange.fire();
+          return;
+        }
+      }
+    }
+    // 2) 選手（末尾優先）。選択しつつドラッグ開始（move せず up なら単なる選択）。
+    const player = hitTestPlayer(data.players, pos);
+    if (player !== undefined) {
+      this.setSelection({ kind: "player", id: player.id });
+      const origin = { ...player.position };
+      this.interaction = {
+        type: "drag-player",
+        playerId: player.id,
+        origin,
+        offsetLat: origin.lateralYard - pos.lateralYard,
+        offsetAbs: origin.absoluteYard - pos.absoluteYard,
+        current: origin,
+      };
+      this._onDidChange.fire();
+      return;
+    }
+    // 3) 線（末尾優先）。
+    const line = hitTestLine(data.lines, data.players, pos);
+    if (line !== undefined) {
+      this.setSelection({ kind: "line", id: line.id });
+      return;
+    }
+    // 4) 何も無ければ選択解除。
+    this.setSelection(null);
+  }
+
+  private drawLinePointerDown(pos: FieldPosition): void {
+    const i = this.interaction;
+    if (i?.type === "draw-line") {
+      // 作図中: クリックごとに中継点を打つ（最後の点が終点になる）。
+      i.points.push({ ...pos });
+      i.cursor = { ...pos };
+      this._onDidChange.fire();
+      return;
+    }
+    // 起点は必ず選手（Model の不変条件）。選手以外で始めようとしたら無視する。
+    const player = hitTestPlayer(this.model.getData().players, pos);
+    if (player === undefined) {
+      return;
+    }
+    this.interaction = {
+      type: "draw-line",
+      startPlayerId: player.id,
+      points: [],
+      cursor: { ...player.position },
+    };
+    this._onDidChange.fire();
+  }
+
+  private addPlayerAt(pos: FieldPosition): void {
+    const taken = new Set(this.model.getData().players.map((p) => p.id));
+    const id = this.ids.next("player", taken);
+    const player: Player = {
+      id,
+      position: { ...pos },
+      shape: DEFAULT_PLAYER_SHAPE,
+      label: "",
+    };
+    this.commands.execute(new AddPlayerCommand(player));
+    this.setSelection({ kind: "player", id });
+  }
+
+  private hitWaypoint(line: Line, pos: FieldPosition): number | undefined {
+    // 末尾優先（後の waypoint ほど手前に描く想定に合わせる）。点距離は
+    // geometry の primitive（退化線分 = 点距離）を再利用し当たり計算を一本化する。
+    for (let idx = line.waypoints.length - 1; idx >= 0; idx--) {
+      const w = line.waypoints[idx] as FieldPosition;
+      if (distanceToSegment(pos, w, w) <= WAYPOINT_HANDLE_RADIUS_YARDS) {
+        return idx;
+      }
+    }
+    return undefined;
+  }
+
+  private lineIds(): Set<string> {
+    return new Set(this.model.getData().lines.map((l) => l.id));
+  }
+}

--- a/src/common/editing/id-factory.test.ts
+++ b/src/common/editing/id-factory.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { IdFactory } from "./id-factory.js";
+
+describe("IdFactory", () => {
+  it("taken が空なら prefix-1 を返す", () => {
+    const factory = new IdFactory();
+
+    expect(factory.next("player", new Set())).toBe("player-1");
+  });
+
+  it("連続呼び出しで単調増加した id を返す", () => {
+    const factory = new IdFactory();
+
+    expect(factory.next("line", new Set())).toBe("line-1");
+    expect(factory.next("line", new Set())).toBe("line-2");
+    expect(factory.next("line", new Set())).toBe("line-3");
+  });
+
+  it("taken に含まれる候補を飛ばして未使用 id を返す", () => {
+    const factory = new IdFactory();
+
+    expect(factory.next("p", new Set(["p-1", "p-2"]))).toBe("p-3");
+  });
+
+  it("prefix ごとにカウンタが独立する", () => {
+    const factory = new IdFactory();
+
+    expect(factory.next("player", new Set())).toBe("player-1");
+    expect(factory.next("line", new Set())).toBe("line-1");
+    expect(factory.next("player", new Set())).toBe("player-2");
+  });
+
+  it("一度払い出した番号は taken から消えても再利用しない", () => {
+    const factory = new IdFactory();
+
+    // p-1 を採番 → その要素を削除（taken から外れる）しても次は p-2。
+    expect(factory.next("p", new Set())).toBe("p-1");
+    expect(factory.next("p", new Set())).toBe("p-2");
+  });
+});

--- a/src/common/editing/id-factory.ts
+++ b/src/common/editing/id-factory.ts
@@ -1,0 +1,32 @@
+// 新規選手/線の安定 id を採番する（編集 UI = M5 の追加操作で使う）。DOM 非依存の純ロジック。
+// 既存 id 集合を渡して衝突を避ける。prefix ごとにカウンタを保持し、削除済み id を
+// 再利用しない（Undo/Redo を跨いでも id が安定し、コマンドの参照が壊れない）。
+
+/**
+ * id 採番の IF。EditorController は具象でなくこれに依存し、テストで決定的な
+ * フェイクへ差し替えられる（インターフェース抽出）。
+ */
+export interface IIdFactory {
+  /** `${prefix}-${n}` 形式で、taken に無い未使用 id を返す。 */
+  next(prefix: string, taken: ReadonlySet<string>): string;
+}
+
+/**
+ * prefix ごとに単調増加するカウンタで id を払い出す。
+ * カウンタは消費後も戻さない＝一度使った番号は（その id が後で消えても）再利用しない。
+ * これにより同一セッション内で id が安定し、Undo で復活した要素とも衝突しない。
+ */
+export class IdFactory implements IIdFactory {
+  private readonly counters = new Map<string, number>();
+
+  next(prefix: string, taken: ReadonlySet<string>): string {
+    let n = this.counters.get(prefix) ?? 0;
+    let id: string;
+    do {
+      n += 1;
+      id = `${prefix}-${n}`;
+    } while (taken.has(id));
+    this.counters.set(prefix, n);
+    return id;
+  }
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -21,6 +21,16 @@ export {
   RemovePlayerCommand,
   UpdatePlayerCommand,
 } from "./commands/player-commands.js";
+export {
+  EditorController,
+  type EditorOverlay,
+  type EditorSelection,
+  type EditorTool,
+  type EditorViewState,
+  type IEditorController,
+  WAYPOINT_HANDLE_RADIUS_YARDS,
+} from "./editing/editor-controller.js";
+export { IdFactory, type IIdFactory } from "./editing/id-factory.js";
 export { Emitter, type Event } from "./event/emitter.js";
 export {
   catmullRomBezierControls,

--- a/src/playmaker.ts
+++ b/src/playmaker.ts
@@ -1,12 +1,16 @@
-import { CanvasSurface } from "./browser/index.js";
+import { CanvasSurface, PointerInput, PropertyPanel, Toolbar } from "./browser/index.js";
 import {
-  cloneLine,
-  clonePlayer,
+  CommandService,
   Disposable,
+  DisposableStore,
+  EditorController,
   type FieldZone,
+  IdFactory,
   type PlayData,
+  PlayModel,
   resolvePlayData,
   toDisposable,
+  UndoRedoService,
 } from "./common/index.js";
 import "./styles.css";
 
@@ -25,29 +29,35 @@ export type {
 export type PlaymakerMode = "view" | "edit";
 
 export interface PlaymakerOptions {
-  /** 既定は "edit"。"view" は読み取り専用（編集 UI を出さない）。 */
+  /** 既定は "edit"。"view" は読み取り専用（編集 UI を出さない・PRD 5.5）。 */
   mode?: PlaymakerMode;
   /** 初期表示するプレー図データ。欠落・古い形式は既定で補完する。 */
   initialData?: PlayData;
-  /** 編集操作のたびに最新の PlayData を通知する（発火は M4 以降）。 */
+  /** 編集操作のたびに最新の PlayData を通知する（暫定契約。確定は M8）。 */
   onChange?: (data: PlayData) => void;
 }
 
 /**
- * ライブラリの公開エントリ。common / browser 層を結線する。
- * 商用ソフト側はコンテナ要素とオプションを渡すだけで使える。
+ * ライブラリの公開エントリ。common（Model/コマンド/Undo/EditorController）と
+ * browser（Canvas/入力/UI）を結線する。商用ソフトはコンテナとオプションを渡すだけ。
+ *
+ * 1 セッション = 1 つの Model + 履歴 + UI。setPlayData は履歴ごと作り直す
+ * （Model は唯一の状態保持者で setData を持たない＝M4 の API を尊重）。
  */
 export class Playmaker extends Disposable {
   readonly mode: PlaymakerMode;
   private readonly root: HTMLElement;
   private readonly surface: CanvasSurface;
-  // Model は Playmaker が専有し、View(CanvasSurface) は描画のみ（Model–View 分離）。
-  private data: PlayData;
+  private readonly options: PlaymakerOptions;
+  // セッション（Model/コマンド/Undo/Controller/UI/入力）。再読込で丸ごと作り直す。
+  private session = new DisposableStore();
+  private model: PlayModel;
+  private controller: EditorController;
 
   constructor(container: HTMLElement, options: PlaymakerOptions = {}) {
     super();
+    this.options = options;
     this.mode = options.mode ?? "edit";
-    this.data = resolvePlayData(options.initialData);
 
     this.root = document.createElement("div");
     this.root.className = "playmaker-root";
@@ -55,33 +65,38 @@ export class Playmaker extends Disposable {
     container.appendChild(this.root);
     this._register(toDisposable(() => this.root.remove()));
 
-    this.surface = this._register(new CanvasSurface(this.root, this.data));
+    this.surface = this._register(
+      new CanvasSurface(this.root, resolvePlayData(options.initialData)),
+    );
+
+    const built = this.buildSession(options.initialData);
+    this.model = built.model;
+    this.controller = built.controller;
   }
 
   /** 現在のフィールドゾーン。 */
   get fieldZone(): FieldZone {
-    return this.data.field.zone;
+    return this.model.getFieldZone();
   }
 
   /**
-   * フィールドゾーンを切り替える（PRD 5.1）。
-   * onChange 通知は編集コマンド機構を入れる M4 以降で配線する。
+   * フィールドゾーンを切り替える（PRD 5.1）。コマンド経由なので Undo/onChange の対象。
+   * view モードでもプログラム API としては有効（編集 UI は出さないだけ）。
    */
   setFieldZone(zone: FieldZone): void {
-    if (zone === this.data.field.zone) {
-      return;
-    }
-    this.data = { ...this.data, field: { ...this.data.field, zone } };
-    this.surface.setData(this.data);
+    this.controller.setFieldZone(zone);
   }
 
   /**
-   * プレー図データを丸ごと投入し直す（PRD 5.2 の「PlayData 投入で選手表示」/ 5.8 再読込）。
+   * プレー図データを丸ごと投入し直す（PRD 5.8 再読込）。履歴はリセットされる。
    * 欠落・古い形式は既定で補完する。正式な往復契約は M8 で確定する。
    */
   setPlayData(data: PlayData): void {
-    this.data = resolvePlayData(data);
-    this.surface.setData(this.data);
+    this.session.dispose();
+    this.session = new DisposableStore();
+    const built = this.buildSession(data);
+    this.model = built.model;
+    this.controller = built.controller;
   }
 
   /**
@@ -89,11 +104,44 @@ export class Playmaker extends Disposable {
    * 正式な往復契約は M8 で確定する。
    */
   getPlayData(): PlayData {
-    return {
-      version: 1,
-      field: { ...this.data.field },
-      players: this.data.players.map(clonePlayer),
-      lines: this.data.lines.map(cloneLine),
-    };
+    return this.model.getData();
+  }
+
+  override dispose(): void {
+    this.session.dispose();
+    super.dispose();
+  }
+
+  /**
+   * Model/コマンド/Undo/Controller/UI/入力を 1 セッションとして構築し session に束ねる。
+   * onDidChange→再描画、model 変更→onChange を配線し、edit のみ UI/入力を出す。
+   */
+  private buildSession(data: PlayData | undefined): {
+    model: PlayModel;
+    controller: EditorController;
+  } {
+    const model = new PlayModel(data);
+    const undoRedo = new UndoRedoService(model);
+    const commands = new CommandService(model, undoRedo);
+    const ids = new IdFactory();
+    const controller = this.session.add(new EditorController(model, commands, undoRedo, ids));
+
+    this.session.add(
+      controller.onDidChange(() =>
+        this.surface.setScene(controller.getRenderModel(), controller.getOverlay()),
+      ),
+    );
+    // Model 変更（編集コマンド・Undo/Redo）のたびに最新 PlayData を通知する。
+    // 構築時は発火しない＝再読込は edit ではないので onChange を出さない。
+    this.session.add(model.onDidChange((snapshot) => this.options.onChange?.(snapshot)));
+
+    if (this.mode === "edit") {
+      this.session.add(new Toolbar(this.root, controller));
+      this.session.add(new PropertyPanel(this.root, controller));
+      this.session.add(new PointerInput(this.surface, controller));
+    }
+
+    this.surface.setScene(controller.getRenderModel(), controller.getOverlay());
+    return { model, controller };
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,7 @@
 /*
  * Playmaker のスタイル。商用ソフト側は --playmaker-* を上書きするだけで
  * 配色・フォント・サイズをデザインシステムに合わせられる（PRD 6.5）。
- * UI（ツールバー/プロパティパネル）は M5 でこの変数体系の上に実装する。
+ * UI（ツールバー/プロパティパネル）は M5 でこの変数体系の上に実装した。
  */
 .playmaker-root {
   --playmaker-font-family: system-ui, sans-serif;
@@ -14,6 +14,7 @@
   --playmaker-line-route-color: #ffeb3b;
   --playmaker-line-block-color: #ffffff;
   --playmaker-line-motion-color: #ffeb3b;
+  --playmaker-selection-color: #ff9800;
   --playmaker-surface-bg: #ffffff;
   --playmaker-border-color: #d0d0d0;
   --playmaker-text-color: #1a1a1a;
@@ -32,4 +33,110 @@
   display: block;
   width: 100%;
   height: 100%;
+}
+
+/*
+ * 編集 UI は Canvas の上に重ねる HTML オーバーレイ（PRD 6.5 / M7 の PNG 除外に有利）。
+ * 配色・サイズは --playmaker-* 由来で商用ソフトのデザインに追従する。
+ */
+.playmaker-toolbar {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px;
+  border: 1px solid var(--playmaker-border-color);
+  border-radius: 6px;
+  background: var(--playmaker-surface-bg);
+  color: var(--playmaker-text-color);
+}
+
+.playmaker-toolbar__button {
+  font: inherit;
+  padding: 4px 10px;
+  border: 1px solid var(--playmaker-border-color);
+  border-radius: 4px;
+  background: var(--playmaker-surface-bg);
+  color: var(--playmaker-text-color);
+  cursor: pointer;
+}
+
+.playmaker-toolbar__button:hover:not(:disabled) {
+  border-color: var(--playmaker-accent-color);
+}
+
+.playmaker-toolbar__button[aria-pressed="true"] {
+  background: var(--playmaker-accent-color);
+  border-color: var(--playmaker-accent-color);
+  color: #ffffff;
+}
+
+.playmaker-toolbar__button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.playmaker-toolbar__sep {
+  width: 1px;
+  align-self: stretch;
+  margin: 0 4px;
+  background: var(--playmaker-border-color);
+}
+
+.playmaker-panel {
+  position: absolute;
+  top: 56px;
+  right: 8px;
+  width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--playmaker-border-color);
+  border-radius: 6px;
+  background: var(--playmaker-surface-bg);
+  color: var(--playmaker-text-color);
+}
+
+.playmaker-panel__title {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.playmaker-panel__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.playmaker-panel__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.85rem;
+}
+
+.playmaker-panel__row input,
+.playmaker-panel__row select {
+  font: inherit;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 2px 4px;
+}
+
+.playmaker-panel__row input[type="color"] {
+  flex: 0 0 auto;
+  width: 40px;
+  padding: 0;
+}
+
+/* view モードでは編集 UI を出さない（PRD 5.5）。保険として CSS でも隠す。 */
+.playmaker-root[data-mode="view"] .playmaker-toolbar,
+.playmaker-root[data-mode="view"] .playmaker-panel {
+  display: none;
 }


### PR DESCRIPTION
### Summary

`docs/plans/implementation-roadmap.md` の次の未完了マイルストーン **M5: edit UI（PRD 5.4）** を実装する。

### Checklist

- [x] Code builds and unit tests pass locally
- [x] Relevant documentation updated
- [x] Reviewer has sufficient context

### Motivation and Context

縦スライス＋common 先行ハイブリッド進行に従い、M0〜M4（描画・コマンド/Undo-Redo 基盤）に続いて編集 UI を載せる。<br>
M4 で common のみに留めた編集ロジックを browser と結線し、PRD 5.4 の編集操作（選手・線の追加/移動/削除/プロパティ編集・waypoint 編集・Undo/Redo・ゾーン切替）・PRD 5.5 の view/edit・PRD 5.8 の onChange を成立させる。

### Implementation Details

編集判断を DOM 非依存の `EditorController`（common）へ集約し node 単体で全網羅、browser は薄い DOM シェルに保つ。<br>
ドラッグ/作図プレビューは Model スナップショットと一時状態の純合成（`getRenderModel`）で表し、実データ変更は 1 コマンド = onChange 1 回（M4 契約）を維持する。<br>
`playmaker.ts` は 1 セッション（Model+履歴+UI）を結線し、`model.onDidChange`→`options.onChange` 発火、edit のみ UI/入力を出し view は読み取り専用にする。

### Testing Instructions

```
pnpm run test
```

`src/common/**` 100% カバレッジゲート内蔵で全件パス（209 tests。編集ロジックの正常・異常・境界・カスケード・Undo/Redo 往復を網羅）。<br>
目視は `pnpm run dev`：ツール（選択/選手追加/線描画）・プロパティ編集・waypoint ドラッグ・Undo/Redo（⌘/Ctrl+Z）・ゾーン切替・view⇄edit 切替・ヘッダー右の `onChange #n`（データ連携）を確認できる。

### Related Issues

なし（ロードマップ M5）。

### Notes for Release

`--playmaker-selection-color` を追加。`Playmaker.setFieldZone` はコマンド経由となり Undo/onChange の対象。`setPlayData` は履歴をリセットする（再読込）。フォーメーション読込=M6、onChange 往復契約の確定=M8、見た目磨き=M9 へ繰り延べ。
