### PR TITLE
feat: M8 データ連携（PlayData 往復・version/migration・onChange 契約確定）を実装する

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -26,6 +26,7 @@
       }
       #controls {
         display: flex;
+        flex-wrap: wrap;
         gap: 6px;
       }
       #controls button {
@@ -38,6 +39,32 @@
         color: #fff;
         border-color: #1565c0;
       }
+      #data {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 6px 12px;
+        border-bottom: 1px solid #ddd;
+      }
+      #data .row {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        font-size: 13px;
+      }
+      #data button {
+        padding: 3px 9px;
+        font: inherit;
+        cursor: pointer;
+      }
+      #data textarea {
+        width: 100%;
+        height: 92px;
+        box-sizing: border-box;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+        resize: vertical;
+      }
       #stage {
         flex: 1;
         min-height: 0;
@@ -47,10 +74,21 @@
   <body>
     <div id="app">
       <header>
-        <span>Playmaker Playground — M7: PNG エクスポート（編集 UI 除外）</span>
+        <span>Playmaker Playground — M8: データ連携（PlayData 往復・version/migration）</span>
         <div id="controls"></div>
         <span id="status" style="margin-left: auto; opacity: 0.7"></span>
       </header>
+      <section id="data">
+        <div class="row">
+          <strong>PlayData JSON</strong>
+          <button id="json-export" type="button">現在の図を JSON へ書き出す</button>
+          <button id="json-import" type="button">JSON を読み込む（往復）</button>
+          <button id="json-legacy" type="button">版なし旧 blob を再現</button>
+          <button id="json-future" type="button">未来版(v99) blob を再現</button>
+          <span id="data-status" style="opacity: 0.7"></span>
+        </div>
+        <textarea id="json" spellcheck="false" aria-label="PlayData JSON"></textarea>
+      </section>
       <div id="stage"></div>
     </div>
     <script type="module" src="/main.ts"></script>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -9,7 +9,11 @@
 //     クリア→攻→守 と重ねると追記セマンティクス（攻守を順に置ける）が分かる。
 // M7: PNG エクスポート。「PNG を出力」で現在のプレー図をダウンロードし、編集 UI が
 //     含まれない（view/edit いずれでも同じ図）ことを目視する。
+// M8: データ連携（PlayData 往復・version/migration）。JSON パネルで getPlayData の
+//     書き出し→読込（setPlayData）の往復、版なし旧 blob・未来版 blob が現行版へ
+//     寄る（migratePlayData）ことを目視する。編集すると onChange で JSON も更新。
 import {
+  CURRENT_PLAY_DATA_VERSION,
   FORMATION_PRESETS,
   type Line,
   type PlayData,
@@ -22,12 +26,22 @@ import {
 const stage = document.getElementById("stage");
 const controlsEl = document.getElementById("controls");
 const statusEl = document.getElementById("status");
-if (!stage || !controlsEl || !statusEl) {
-  throw new Error("#stage / #controls / #status が見つかりません");
+const jsonEl = document.getElementById("json");
+const dataStatusEl = document.getElementById("data-status");
+if (
+  !stage ||
+  !controlsEl ||
+  !statusEl ||
+  !(jsonEl instanceof HTMLTextAreaElement) ||
+  !dataStatusEl
+) {
+  throw new Error("#stage / #controls / #status / #json / #data-status が見つかりません");
 }
 const controls: HTMLElement = controlsEl;
 const status: HTMLElement = statusEl;
 const mountPoint: HTMLElement = stage;
+const jsonArea: HTMLTextAreaElement = jsonEl;
+const dataStatus: HTMLElement = dataStatusEl;
 
 // M2/M3 目視用サンプル: 6 形状・色・ラベル・3 線種・直線/ベジェ・waypoint。
 const DEFENSE_COLOR = "#c62828";
@@ -148,6 +162,32 @@ let changeCount = 0;
 function onChange(data: PlayData): void {
   changeCount += 1;
   status.textContent = `onChange #${changeCount}｜選手 ${data.players.length}・線 ${data.lines.length}・ゾーン ${data.field.zone}`;
+  // version の現行確定を編集ごとに目視できるよう通知データをそのまま出す。
+  jsonArea.value = JSON.stringify(data, null, 2);
+}
+
+/** 現在のプレー図（正準スナップショット）を JSON 欄へ書き出す。 */
+function refreshJson(): void {
+  jsonArea.value = JSON.stringify(playmaker.getPlayData(), null, 2);
+}
+
+/**
+ * JSON 欄の内容を setPlayData で読み込み、結果を再表示する。
+ * setPlayData は onChange を発火しない契約なので明示的に書き戻し、版なし/未来版
+ * blob が現行版へ寄る（migratePlayData）ことを往復として目視できる。
+ */
+function loadFromJsonText(): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonArea.value);
+  } catch (error) {
+    dataStatus.textContent = `JSON 解析エラー: ${(error as Error).message}`;
+    return;
+  }
+  // 旧版・未来版・破損も migratePlayData が現行へ寄せる前提で型を緩めて渡す。
+  playmaker.setPlayData(parsed as PlayData);
+  refreshJson();
+  dataStatus.textContent = "読込完了（version は現行へ寄せて再表示）";
 }
 
 function create(initialData?: PlayData): Playmaker {
@@ -162,7 +202,7 @@ function create(initialData?: PlayData): Playmaker {
 }
 
 let playmaker = create({
-  version: 1,
+  version: CURRENT_PLAY_DATA_VERSION,
   field: { zone: "middle" },
   players: SAMPLE_PLAYERS,
   lines: SAMPLE_LINES,
@@ -178,20 +218,22 @@ function addAction(label: string, onClick: () => void): HTMLButtonElement {
 
 addAction("サンプル隊形＋線を読み込む", () => {
   playmaker.setPlayData({
-    version: 1,
+    version: CURRENT_PLAY_DATA_VERSION,
     field: { zone: playmaker.fieldZone },
     players: SAMPLE_PLAYERS,
     lines: SAMPLE_LINES,
   });
+  refreshJson();
 });
 
 addAction("クリア", () => {
   playmaker.setPlayData({
-    version: 1,
+    version: CURRENT_PLAY_DATA_VERSION,
     field: { zone: playmaker.fieldZone },
     players: [],
     lines: [],
   });
+  refreshJson();
 });
 
 // 公開 API loadFormation の目視（追記）。クリア→攻→守 の順で重ねられる。
@@ -221,6 +263,7 @@ const modeButton = addAction("", () => {
   mode = mode === "edit" ? "view" : "edit";
   playmaker = create(snapshot);
   syncModeButton();
+  refreshJson();
 });
 
 function syncModeButton(): void {
@@ -230,6 +273,53 @@ function syncModeButton(): void {
 
 syncModeButton();
 
+// JSON パネル（M8 往復・migration の目視）。静的 HTML のボタンに結線する。
+// 静的 HTML ボタンは HMR を跨いで生き残るため、signal でリスナを束ね再読込時に外す
+// （束ねないとホットリロードごとに多重登録され 1 クリックで多重発火する）。
+const demoLifetime = new AbortController();
+
+function bindButton(id: string, onClick: () => void): void {
+  const button = document.getElementById(id);
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`#${id} が見つかりません`);
+  }
+  button.addEventListener("click", onClick, { signal: demoLifetime.signal });
+}
+
+/** 任意 blob を JSON 欄へ流し込み読込まで通す（旧版/未来版 fixture の目視に共通）。 */
+function loadFixture(blob: unknown): void {
+  jsonArea.value = JSON.stringify(blob, null, 2);
+  loadFromJsonText();
+}
+
+bindButton("json-export", () => {
+  refreshJson();
+  dataStatus.textContent = "現在の getPlayData を書き出し";
+});
+bindButton("json-import", loadFromJsonText);
+// version フィールドの無い商用ソフト初期データ → 読込で現行版へ寄る。
+bindButton("json-legacy", () =>
+  loadFixture({
+    field: { zone: "own-redzone" },
+    players: [{ id: "wr", position: { lateralYard: 5, absoluteYard: 50 }, shape: "square" }],
+  }),
+);
+// 新しい lib で保存された未来版 → 前方互換で現行へ寄り未知項目は落ちる。
+bindButton("json-future", () =>
+  loadFixture({
+    version: 99,
+    field: { zone: "redzone" },
+    players: [{ id: "qb", position: { lateralYard: 26, absoluteYard: 48 }, shape: "circle" }],
+    lines: [],
+    futureOnlyField: { whatever: true },
+  }),
+);
+
+refreshJson();
+
 if (import.meta.hot) {
-  import.meta.hot.dispose(() => playmaker.dispose());
+  import.meta.hot.dispose(() => {
+    demoLifetime.abort();
+    playmaker.dispose();
+  });
 }

--- a/docs/plans/implementation-roadmap.md
+++ b/docs/plans/implementation-roadmap.md
@@ -248,6 +248,61 @@ PRD 5.7 を VSCode 流の軽量適用で実装。寸法決定（純計算）を 
 - `IPlayModel` 軽量 id 取得 API（M5/M6 と同イディオム、`exportToPng` も `getData()`
   全複製を経由）= **M9 仕上げ**（現規模で実害なし）
 
+### 実装メモ：データ連携仕上げ（PlayData 往復・version/migration・onChange 契約確定）（2026-05-17, M8）
+
+PRD 5.8 / 6.6 を VSCode 流の軽量適用で実装。版検出・段適用（純計算）を common に
+寄せて node 単体で全網羅し、browser/公開層は契約確定（ドキュメント）と funnel
+結線のみに留めた。M4〜M7 が繰り延べてきた「`onChange` の往復契約（version/
+migration 含む確定）」をここで凍結した。
+
+**M8 で確定（common: model/migration・テスト済 / 254 tests・common 100%・v8 ignore 0）**
+- `CURRENT_PLAY_DATA_VERSION`（play-data.ts）= version の**真実源 1 か所**。
+  `createEmptyPlayData`/`clonePlayData`/`resolvePlayData` がこれを参照し、`PlayData.version`
+  も `typeof` で束ねる（スキーマ進化時の更新漏れを型で防ぐ）
+- `migratePlayData(raw: unknown)` = 永続 blob → 現行 PlayData の**唯一の公開境界
+  funnel**：版検出（`readDeclaredVersion`・数値以外/非object は版なし=0 扱い）→
+  旧→現行の段適用（`applyPlayDataMigrations`）→ 構造正規化（`resolvePlayData`）。
+  決して投げず version は現行へ確定、内部状態と切り離した新規オブジェクトを返す。
+  `resolvePlayData`/`normalizeFormation`/`resolveImageExportSize` と同じ公開境界の
+  防御正規化作法に揃えた
+- **空エンジンの死コードを置かない判断**：greenfield 単一版では generic な段適用
+  ループ本体が本番経路で未実行＝「common 100% / `v8 ignore` 0」規律と衝突する。
+  そこで `applyPlayDataMigrations` は段を**引数注入**にし、フェイク段で適用/スキップ
+  /非object/null の全分岐を単体テスト（VSCode 流フェイク注入）。本番の
+  `PLAY_DATA_MIGRATIONS` は**空配列＝コードでなくデータ**（カバレッジ対象外）。
+  v2 追加手順（CURRENT を +1・段を 1 つ足す・その段をテスト）はコード comment と
+  本メモに明示＝拡張点を「監査済みの判断」にして 100% を素直に維持
+- 旧版・版なしは 0 扱いで現行へ収束（`resolvePlayData` が旧来の不完全データを
+  既定補完）。未来版（新 lib で保存→旧 lib で復元）は適用段が無く前方互換の
+  ベストエフォート＝未知項目は `resolvePlayData` が落とすだけで投げない
+- `PlayModel` 構築を `migratePlayData` 経由へ統一（inbound の唯一の入口）。
+  `Playmaker` の `CanvasSurface` seed も `migratePlayData` に揃えた
+
+**M8 で確定（browser/公開: 契約凍結・最小限・VRT なし）**
+- **`onChange` 往復契約を凍結**：編集コマンドおよび Undo/Redo の確定ごとに
+  **1 回**、最新 PlayData の深いスナップショット（`version` は常に現行・内部状態と
+  分離＝受け手の書換えが波及しない）。構築時・`setPlayData` 再読込・PNG 出力では
+  非発火（再読込・出力は編集ではない）。`getPlayData` = 正準スナップショットで
+  そのまま JSON 化して永続化でき、`setPlayData`/`initialData` に戻すと同値復元
+  （M4 の「1 コマンド = onChange 1 回」を往復契約として確定）。型 doc から
+  「暫定。確定は M8」を除去し確定文へ差し替え
+- 公開面に `CURRENT_PLAY_DATA_VERSION` / `migratePlayData` を出す（商用ソフトが
+  契約を使える形に）。`applyPlayDataMigrations`/`PLAY_DATA_MIGRATIONS`/
+  `PlayDataMigration` は common 内部に留める（拡張機構＝MVP 公開面は PRD 4.1 で絞る）
+- demo は JSON パネルで「書き出し→読込（往復）」と「版なし旧 blob・未来版(v99)
+  blob が現行版へ寄る」ことを目視。編集確定で `onChange` 経由に JSON も同期更新
+
+**M9 へ繰り延べ**
+- `scale`/DPR・透過背景・余白指定・出力体裁の磨き（M7 既述）= **M9**
+- `IPlayModel` 軽量 id 取得 API（M5/M6/M7 と同イディオム、`getData()` 全複製を共有）
+  = **M9 仕上げ**（現規模で実害なし）
+- 構築時 `initialData` の二重正規化（`Playmaker` の `CanvasSurface` seed と
+  `PlayModel` が各々 funnel を通す）。**M8 以前から存在**（旧 `resolvePlayData` ×2 を
+  M8 で `migratePlayData` ×2 に差し替えただけで挙動不変）。seed は直後の `setScene` で
+  上書きされ可逆、構築 1 回のみで hot path でない。上記 id 取得 API と同じ
+  「構築・複製コスト最適化」族として **M9 仕上げ**へ集約（監査済みの意図的判断）
+- プリセット座標の戦術精緻化・実フィールド/記法準拠の見た目磨き = **M9**
+
 ### 完了判定（PRD 7 章）
 - 機能要件（PRD 5 章）すべてが仕様通り動作
 - `common` 層の単体テストおよび統合テストが通る

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -95,6 +95,14 @@ export {
   normalizeLines,
 } from "./model/line.js";
 export {
+  applyPlayDataMigrations,
+  migratePlayData,
+  PLAY_DATA_MIGRATIONS,
+  type PlayDataMigration,
+  readDeclaredVersion,
+} from "./model/migration.js";
+export {
+  CURRENT_PLAY_DATA_VERSION,
   clonePlayData,
   createEmptyPlayData,
   DEFAULT_FIELD_ZONE,

--- a/src/common/model/migration.test.ts
+++ b/src/common/model/migration.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPlayDataMigrations,
+  migratePlayData,
+  type PlayDataMigration,
+  readDeclaredVersion,
+} from "./migration.js";
+import { CURRENT_PLAY_DATA_VERSION, type PlayData } from "./play-data.js";
+
+describe("readDeclaredVersion", () => {
+  it("有限数の version をそのまま返す", () => {
+    expect(readDeclaredVersion({ version: 1 })).toBe(1);
+    expect(readDeclaredVersion({ version: 2 })).toBe(2);
+    expect(readDeclaredVersion({ version: 0 })).toBe(0);
+  });
+
+  it("version が数値でなければ版の宣言なし(0)とみなす", () => {
+    expect(readDeclaredVersion({ version: "1" })).toBe(0);
+    expect(readDeclaredVersion({ version: null })).toBe(0);
+    expect(readDeclaredVersion({})).toBe(0);
+  });
+
+  it("非有限数(NaN/Infinity)も版の宣言なし(0)とみなす", () => {
+    expect(readDeclaredVersion({ version: Number.NaN })).toBe(0);
+    expect(readDeclaredVersion({ version: Number.POSITIVE_INFINITY })).toBe(0);
+  });
+
+  it("オブジェクトでない/null の blob は 0 を返す", () => {
+    expect(readDeclaredVersion(undefined)).toBe(0);
+    expect(readDeclaredVersion(null)).toBe(0);
+    expect(readDeclaredVersion("nope")).toBe(0);
+    expect(readDeclaredVersion(7)).toBe(0);
+  });
+});
+
+describe("applyPlayDataMigrations", () => {
+  // 段注入で「適用/スキップ」両分岐を UI/レジストリ無しに検証する（VSCode 流フェイク注入）。
+  const steps: readonly PlayDataMigration[] = [
+    { to: 1, migrate: (d) => ({ ...d, v1: true }) },
+    { to: 2, migrate: (d) => ({ ...d, v2: true }) },
+  ];
+
+  it("宣言版より新しい段だけを to 昇順に適用する", () => {
+    expect(applyPlayDataMigrations({ base: true }, 0, steps)).toEqual({
+      base: true,
+      v1: true,
+      v2: true,
+    });
+  });
+
+  it("宣言版以下の段はスキップする（境界 to === declared も適用しない）", () => {
+    // declared=1: to:1 はスキップ（false 分岐）、to:2 のみ適用。
+    expect(applyPlayDataMigrations({ base: true }, 1, steps)).toEqual({ base: true, v2: true });
+    // declared=2: 全段スキップ＝未来版の前方互換（素通し）。
+    expect(applyPlayDataMigrations({ base: true }, 2, steps)).toEqual({ base: true });
+  });
+
+  it("段が空なら入力をそのまま返す（現行 lib の本番経路）", () => {
+    const input = { version: 1 };
+
+    expect(applyPlayDataMigrations(input, 0, [])).toBe(input);
+  });
+
+  it("オブジェクトでない/null の blob は段適用せず素通しする", () => {
+    expect(applyPlayDataMigrations("garbage", 0, steps)).toBe("garbage");
+    expect(applyPlayDataMigrations(undefined, 0, steps)).toBe(undefined);
+    expect(applyPlayDataMigrations(null, 0, steps)).toBe(null);
+  });
+});
+
+describe("migratePlayData", () => {
+  it("undefined/破損 blob でも投げず空の現行 PlayData を返す", () => {
+    const empty = {
+      version: CURRENT_PLAY_DATA_VERSION,
+      field: { zone: "middle" },
+      players: [],
+      lines: [],
+    };
+
+    expect(migratePlayData(undefined)).toEqual(empty);
+    expect(migratePlayData("garbage")).toEqual(empty);
+    expect(migratePlayData(42)).toEqual(empty);
+    expect(migratePlayData(null)).toEqual(empty);
+  });
+
+  it("正当な現行 PlayData は構造を保ち入力と切り離した新規オブジェクトを返す", () => {
+    const input: PlayData = {
+      version: 1,
+      field: { zone: "redzone" },
+      players: [
+        { id: "qb", position: { lateralYard: 26, absoluteYard: 48 }, shape: "circle", label: "QB" },
+      ],
+      lines: [
+        {
+          id: "r1",
+          kind: "route",
+          startPlayerId: "qb",
+          waypoints: [],
+          end: { lateralYard: 30, absoluteYard: 56 },
+          interpolation: "straight",
+        },
+      ],
+    };
+
+    const migrated = migratePlayData(input);
+
+    expect(migrated).toEqual(input);
+    expect(migrated).not.toBe(input);
+    expect(migrated.players[0]).not.toBe(input.players[0]);
+    expect(migrated.lines[0]).not.toBe(input.lines[0]);
+  });
+
+  it("版なしの旧来 blob を現行版へ引き上げ、復元可能な構造は保持する", () => {
+    // 商用ソフト初期の未バージョン化データ（version フィールドが無い）。
+    const legacy = {
+      field: { zone: "own-redzone" },
+      players: [{ id: "wr", position: { lateralYard: 5, absoluteYard: 50 }, shape: "square" }],
+    } as unknown;
+
+    const migrated = migratePlayData(legacy);
+
+    expect(migrated.version).toBe(CURRENT_PLAY_DATA_VERSION);
+    expect(migrated.field.zone).toBe("own-redzone");
+    expect(migrated.players).toEqual([
+      { id: "wr", position: { lateralYard: 5, absoluteYard: 50 }, shape: "square", label: "" },
+    ]);
+    expect(migrated.lines).toEqual([]);
+  });
+
+  it("未来版 blob は前方互換で現行へ寄せ、未知フィールドは落として投げない", () => {
+    const future = {
+      version: 99,
+      field: { zone: "middle" },
+      players: [{ id: "qb", position: { lateralYard: 26, absoluteYard: 48 }, shape: "circle" }],
+      lines: [],
+      futureOnlyField: { whatever: true },
+    } as unknown;
+
+    const migrated = migratePlayData(future);
+
+    expect(migrated.version).toBe(CURRENT_PLAY_DATA_VERSION);
+    expect(migrated).not.toHaveProperty("futureOnlyField");
+    expect(migrated.players.map((p) => p.id)).toEqual(["qb"]);
+  });
+
+  it("getData→JSON→migratePlayData の往復で同値に戻る（PRD 5.8 往復契約）", () => {
+    const persisted: PlayData = {
+      version: 1,
+      field: { zone: "redzone" },
+      players: [
+        { id: "x", position: { lateralYard: 7, absoluteYard: 49 }, shape: "circle", label: "X" },
+      ],
+      lines: [
+        {
+          id: "rt",
+          kind: "route",
+          startPlayerId: "x",
+          waypoints: [{ lateralYard: 7, absoluteYard: 55 }],
+          end: { lateralYard: 13, absoluteYard: 59 },
+          interpolation: "bezier",
+        },
+      ],
+    };
+
+    const roundTripped = migratePlayData(JSON.parse(JSON.stringify(persisted)));
+
+    expect(roundTripped).toEqual(persisted);
+  });
+});

--- a/src/common/model/migration.ts
+++ b/src/common/model/migration.ts
@@ -1,0 +1,82 @@
+// PlayData の version 検出 → 旧→現行マイグレーション段適用 → 構造正規化を
+// 1 本の公開境界 funnel にまとめる（PRD 6.6 データバージョニング）。
+//
+// 永続化・復元は商用ソフトの責務（PRD 5.8）。ここへ復元されてくる blob は
+// 現行版 / 旧版・版なし / 未来版（新しい lib で保存→古い lib で復元）/ 破損 JSON の
+// いずれもありうる。よって「決して投げず、常に現行スキーマへ寄せる」公開境界の
+// 防御作法を resolvePlayData / normalizeFormation / resolveImageExportSize と揃え、
+// inbound 経路（PlayModel 構築・Playmaker.setPlayData）の唯一の入口にする。
+
+import { type PlayData, resolvePlayData } from "./play-data.js";
+
+/**
+ * 旧版 blob を 1 つ上の版の形へ寄せる段。構造の最終正規化は resolvePlayData が
+ * 担うので、各段は「次版で意味が変わる項目だけ」を変換すればよい。
+ */
+export interface PlayDataMigration {
+  /** この段を適用すると version はこの値になる（段は `to` 昇順に適用）。 */
+  readonly to: number;
+  migrate(data: Record<string, unknown>): Record<string, unknown>;
+}
+
+/**
+ * 旧→現行のマイグレーション段（`to` 昇順）。v1 が最初の版なので現状は空。
+ *
+ * スキーマを v2 へ進めるとき:
+ *   1. play-data.ts の CURRENT_PLAY_DATA_VERSION を 2 にする
+ *   2. ここへ `{ to: 2, migrate }` を足す（v1 blob を v2 の形へ寄せる）
+ *   3. その段の単体テストを書く
+ * エンジン applyPlayDataMigrations は段を注入して全分岐を単体テスト済みなので、
+ * 段を足しても funnel 自体の経路は緑のまま拡張できる（PRD 6.6 の契約点）。
+ */
+export const PLAY_DATA_MIGRATIONS: readonly PlayDataMigration[] = [];
+
+/**
+ * blob から宣言バージョンを取り出す。数値（有限）でなければ「版の宣言なし」とみなし
+ * 0 を返す＝最初期の未バージョン化データ扱いで現行へ引き上げる対象になる。
+ */
+export function readDeclaredVersion(raw: unknown): number {
+  if (typeof raw === "object" && raw !== null) {
+    const value = (raw as { version?: unknown }).version;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return 0;
+}
+
+/**
+ * 宣言版より新しい段だけを `to` 昇順に適用する純粋エンジン。段は引数注入なので
+ * UI/レジストリ無しで全分岐を単体テストできる（VSCode 流のフェイク注入）。
+ * オブジェクトでない blob は段適用せず素通し（構造正規化が既定補完する）。
+ * 宣言版が最終段以上なら適用段が無く blob はそのまま＝未来版の前方互換。
+ */
+export function applyPlayDataMigrations(
+  raw: unknown,
+  declaredVersion: number,
+  steps: readonly PlayDataMigration[],
+): unknown {
+  if (typeof raw !== "object" || raw === null) {
+    return raw;
+  }
+  let acc = raw as Record<string, unknown>;
+  for (const step of steps) {
+    if (step.to > declaredVersion) {
+      acc = step.migrate(acc);
+    }
+  }
+  return acc;
+}
+
+/**
+ * 永続化された任意の blob を現行スキーマの PlayData にする唯一の公開境界 funnel。
+ * 版検出 → 旧→現行の段適用 → 構造正規化（resolvePlayData）。決して投げず、
+ * version は常に CURRENT_PLAY_DATA_VERSION に確定し、内部状態と切り離した新規
+ * オブジェクトを返す（受け手が書き換えても波及しない＝PRD 5.8 の往復契約）。
+ */
+export function migratePlayData(raw: unknown): PlayData {
+  const declared = readDeclaredVersion(raw);
+  const migrated = applyPlayDataMigrations(raw, declared, PLAY_DATA_MIGRATIONS);
+  // resolvePlayData は CURRENT を刻むので、未来版も含め version は現行に確定する。
+  return resolvePlayData(migrated as PlayData | undefined);
+}

--- a/src/common/model/play-data.ts
+++ b/src/common/model/play-data.ts
@@ -22,10 +22,17 @@ export interface FieldState {
 }
 
 /**
- * プレー図データ。`version` でスキーマ進化に備える（マイグレーション機構は M8）。
+ * 現在の PlayData スキーマ版。スキーマを変えるたびに +1 し、`migratePlayData` の
+ * 段（`PLAY_DATA_MIGRATIONS`）に旧→新の変換を 1 つ足す。version の真実源はここ 1 か所。
+ */
+export const CURRENT_PLAY_DATA_VERSION = 1 as const;
+
+/**
+ * プレー図データ。`version` でスキーマ進化に備え、復元時は `migratePlayData` が
+ * 旧版・版なし・未来版いずれも現行へ寄せる（PRD 6.6 の往復契約）。
  */
 export interface PlayData {
-  version: 1;
+  version: typeof CURRENT_PLAY_DATA_VERSION;
   field: FieldState;
   /** 配置済みの選手（描画順 = 配列順。後の要素ほど上に重なる）。 */
   players: Player[];
@@ -39,7 +46,12 @@ export function isFieldZone(value: unknown): value is FieldZone {
 
 /** 既定状態の新規 PlayData（選手・線なし）。 */
 export function createEmptyPlayData(): PlayData {
-  return { version: 1, field: { zone: DEFAULT_FIELD_ZONE }, players: [], lines: [] };
+  return {
+    version: CURRENT_PLAY_DATA_VERSION,
+    field: { zone: DEFAULT_FIELD_ZONE },
+    players: [],
+    lines: [],
+  };
 }
 
 /**
@@ -49,7 +61,7 @@ export function createEmptyPlayData(): PlayData {
  */
 export function clonePlayData(data: PlayData): PlayData {
   return {
-    version: 1,
+    version: CURRENT_PLAY_DATA_VERSION,
     field: { ...data.field },
     players: data.players.map(clonePlayer),
     lines: data.lines.map(cloneLine),
@@ -57,10 +69,10 @@ export function clonePlayData(data: PlayData): PlayData {
 }
 
 /**
- * 外部（商用ソフト）から渡る initialData を内部で安全に扱える形へ正規化する。
- * 永続化された古い／不完全なデータでも落とさず既定で補完する（PRD 6.6 の契約準備）。
- * 返り値は常に新規オブジェクトで、入力を共有・変更しない（Model 専有のため）。
- * 本格的な version マイグレーションは M8 で確定する。
+ * blob を現行スキーマの構造へ正規化する（version 検出・段適用は `migratePlayData`）。
+ * 永続化された古い／不完全なデータでも落とさず既定で補完する。返り値は常に新規
+ * オブジェクトで入力を共有・変更しない（Model 専有）。version マイグレーション段を
+ * 通した後の最終正規化として `migratePlayData` から呼ばれる（PRD 6.6 の往復契約）。
  */
 export function resolvePlayData(data: PlayData | undefined): PlayData {
   const zone = data?.field?.zone;
@@ -68,7 +80,7 @@ export function resolvePlayData(data: PlayData | undefined): PlayData {
   const players = normalizePlayers(data?.players);
   const validPlayerIds = new Set(players.map((p) => p.id));
   return {
-    version: 1,
+    version: CURRENT_PLAY_DATA_VERSION,
     field: { zone: isFieldZone(zone) ? zone : DEFAULT_FIELD_ZONE },
     players,
     lines: normalizeLines(data?.lines, validPlayerIds),

--- a/src/common/model/play-model.test.ts
+++ b/src/common/model/play-model.test.ts
@@ -56,6 +56,20 @@ describe("PlayModel 構築", () => {
 
     expect(model.findPlayer("a")?.label).toBe("a");
   });
+
+  it("版なしの旧来 blob も migratePlayData 経由で現行版へ寄せて取り込む", () => {
+    // 商用ソフトが永続化した未バージョン化データの再読込（PRD 6.6 唯一の入口）。
+    const legacy = {
+      field: { zone: "redzone" },
+      players: [{ id: "wr", position: { lateralYard: 5, absoluteYard: 50 }, shape: "square" }],
+    } as unknown as PlayData;
+
+    const model = new PlayModel(legacy);
+
+    expect(model.getData().version).toBe(1);
+    expect(model.getFieldZone()).toBe("redzone");
+    expect(model.findPlayer("wr")?.shape).toBe("square");
+  });
 });
 
 describe("PlayModel 参照系", () => {

--- a/src/common/model/play-model.ts
+++ b/src/common/model/play-model.ts
@@ -4,7 +4,8 @@
 
 import { Emitter, type Event } from "../event/emitter.js";
 import { cloneLine, type Line } from "./line.js";
-import { clonePlayData, type FieldZone, type PlayData, resolvePlayData } from "./play-data.js";
+import { migratePlayData } from "./migration.js";
+import { clonePlayData, type FieldZone, type PlayData } from "./play-data.js";
 import { clonePlayer, type Player } from "./player.js";
 
 /**
@@ -76,11 +77,12 @@ function insertAt<T>(items: readonly T[], index: number, item: T): T[] {
 export class PlayModel implements IPlayModel {
   private readonly _onDidChange = new Emitter<PlayData>();
   readonly onDidChange = this._onDidChange.event;
-  // resolvePlayData が深い新規オブジェクトを返す＝外部入力と完全に切り離した内部状態。
+  // migratePlayData が版検出→段適用→構造正規化した深い新規オブジェクトを返す
+  // ＝外部入力（旧版・破損含む）と完全に切り離した内部状態（PRD 6.6 の唯一の入口）。
   private state: PlayData;
 
   constructor(initialData?: PlayData) {
-    this.state = resolvePlayData(initialData);
+    this.state = migratePlayData(initialData);
   }
 
   getData(): PlayData {

--- a/src/playmaker.ts
+++ b/src/playmaker.ts
@@ -8,10 +8,10 @@ import {
   type Formation,
   IdFactory,
   type ImageExportOptions,
+  migratePlayData,
   normalizeFormation,
   type PlayData,
   PlayModel,
-  resolvePlayData,
   toDisposable,
   UndoRedoService,
 } from "./common/index.js";
@@ -32,16 +32,30 @@ export type {
   Player,
   PlayerShape,
 } from "./common/index.js";
-export { FORMATION_PRESETS, getFormationPreset } from "./common/index.js";
+export {
+  CURRENT_PLAY_DATA_VERSION,
+  FORMATION_PRESETS,
+  getFormationPreset,
+  migratePlayData,
+} from "./common/index.js";
 
 export type PlaymakerMode = "view" | "edit";
 
 export interface PlaymakerOptions {
   /** 既定は "edit"。"view" は読み取り専用（編集 UI を出さない・PRD 5.5）。 */
   mode?: PlaymakerMode;
-  /** 初期表示するプレー図データ。欠落・古い形式は既定で補完する。 */
+  /**
+   * 初期表示するプレー図データ。商用ソフトが永続化した PlayData をそのまま渡せる。
+   * 旧版・版なし・未来版・破損データでも `migratePlayData` が現行スキーマへ寄せる
+   * （決して投げず復元不能要素のみ除外＝PRD 6.6 の往復契約）。
+   */
   initialData?: PlayData;
-  /** 編集操作のたびに最新の PlayData を通知する（暫定契約。確定は M8）。 */
+  /**
+   * 編集確定契約（PRD 5.8）：編集コマンドおよび Undo/Redo の確定ごとに **1 回**、
+   * 最新 PlayData の深いスナップショット（`version` は常に現行・内部状態と分離）を渡す。
+   * 受け手はそのまま永続化でき、書き換えても内部に波及しない。構築時・`setPlayData`
+   * での再読込・PNG 出力では発火しない（再読込は編集ではない）。
+   */
   onChange?: (data: PlayData) => void;
 }
 
@@ -74,7 +88,7 @@ export class Playmaker extends Disposable {
     this._register(toDisposable(() => this.root.remove()));
 
     this.surface = this._register(
-      new CanvasSurface(this.root, resolvePlayData(options.initialData)),
+      new CanvasSurface(this.root, migratePlayData(options.initialData)),
     );
 
     const built = this.buildSession(options.initialData);
@@ -111,8 +125,10 @@ export class Playmaker extends Disposable {
   }
 
   /**
-   * プレー図データを丸ごと投入し直す（PRD 5.8 再読込）。履歴はリセットされる。
-   * 欠落・古い形式は既定で補完する。正式な往復契約は M8 で確定する。
+   * 商用ソフトが永続化した PlayData を後から丸ごと再読込する（PRD 5.8）。
+   * 旧版・版なし・未来版・破損データでも `migratePlayData` が現行へ寄せ、決して
+   * 投げない。1 セッション = 1 Model なので履歴はリセットされ、再読込は編集では
+   * ないため `onChange` は発火しない（編集確定のみが通知契約＝PRD 6.6）。
    */
   setPlayData(data: PlayData): void {
     this.session.dispose();
@@ -123,8 +139,9 @@ export class Playmaker extends Disposable {
   }
 
   /**
-   * 現在の PlayData のスナップショット（防御的コピー）。
-   * 正式な往復契約は M8 で確定する。
+   * 現在のプレー図の正準スナップショット（深い防御的コピー・`version` は現行）。
+   * そのまま JSON 化して永続化でき、後で `setPlayData` / `initialData` に戻すと
+   * 同値のプレー図に復元される（PRD 5.8 / 6.6 の往復契約）。
    */
   getPlayData(): PlayData {
     return this.model.getData();


### PR DESCRIPTION
### Summary

ロードマップ M8「データ連携仕上げ」を実装する（PRD 5.8 / 6.6）。<br>
PlayData の往復・version/migration 機構・onChange 契約を確定した。

### Checklist

- [x] Code builds and unit tests pass locally
- [x] Relevant documentation updated
- [x] Reviewer has sufficient context

### Motivation and Context

商用ソフトが PlayData を永続化・復元する責務を持つため、その境界の契約を明確化する必要がある（PRD 6.6）。<br>
M4〜M7 が「onChange の往復契約（version/migration 含む確定）」を一貫して M8 へ繰り延べてきた。

### Implementation Details

永続 blob（現行版・旧版/版なし・未来版・破損）を現行スキーマへ寄せ決して投げない唯一の公開境界 funnel `migratePlayData`（版検出 → 段適用 → 構造正規化）を確定し、PlayModel 構築と CanvasSurface seed をそこへ統一した。<br>
version の真実源を `CURRENT_PLAY_DATA_VERSION` 1 か所に集約し、onChange/initialData/setPlayData/getPlayData の往復契約を doc から「暫定」を外して凍結した。

### Testing Instructions

`pnpm run test`（254 tests 全件パス・`src/common/**` 100% perFile カバレッジゲート内蔵）。<br>
`pnpm run dev` で playground を開き、JSON パネルの「書き出し→読込（往復）」と「版なし旧 blob・未来版(v99) blob が現行版へ寄る」ことを目視する。

### Related Issues

特になし（ロードマップ M8）。

### Notes for Release

公開 API 追加: `CURRENT_PLAY_DATA_VERSION` / `migratePlayData`（破壊的変更なし）。<br>
設計判断（空マイグレーションエンジンを置かず段注入で common 100%/v8 ignore 0 を維持、v2 拡張点の明示、構築時二重正規化の M9 繰り延べ）は `docs/plans/implementation-roadmap.md` の M8 実装メモを参照。
