### PR TITLE
feat: フィールド描画とプレー作図をNCAA仕様にプロフェッショナル化する

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,5 +1,5 @@
 // ローカル確認用 playground のエントリ。手元のブラウザで以下を目視する:
-// - フィールド描画とゾーン切替、6 形状・色・ラベルの選手、route/block/motion の線
+// - フィールド描画とゾーン切替、2 形状（丸/四角）・色・ラベルの選手、route/block/motion の線
 // - 内蔵 UI（ツールバー/プロパティパネル/Undo·Redo/ゾーン切替）での編集と view/edit 切替
 // - フォーメーション読込（内蔵プルダウンと公開 API loadFormation の追記セマンティクス）
 // - PNG エクスポート（編集 UI を含まない・view/edit で同一図）
@@ -38,8 +38,8 @@ const mountPoint: HTMLElement = stage;
 const jsonArea: HTMLTextAreaElement = jsonEl;
 const dataStatus: HTMLElement = dataStatusEl;
 
-// 目視用サンプル: 6 形状・色・ラベル・3 線種・直線/ベジェ・waypoint。
-const DEFENSE_COLOR = "#c62828";
+// 目視用サンプル: 2 形状（丸/四角）・色・ラベル・3 線種・直線/ベジェ・waypoint。
+const DEFENSE_COLOR = "#b23a30";
 const SAMPLE_PLAYERS: Player[] = [
   { id: "ol-c", position: { lateralYard: 26.7, absoluteYard: 49 }, shape: "square", label: "C" },
   { id: "ol-lg", position: { lateralYard: 24.4, absoluteYard: 49 }, shape: "square", label: "LG" },
@@ -47,50 +47,50 @@ const SAMPLE_PLAYERS: Player[] = [
   { id: "ol-lt", position: { lateralYard: 22.1, absoluteYard: 49 }, shape: "square", label: "LT" },
   { id: "ol-rt", position: { lateralYard: 31.3, absoluteYard: 49 }, shape: "square", label: "RT" },
   { id: "qb", position: { lateralYard: 26.7, absoluteYard: 46.5 }, shape: "circle", label: "QB" },
-  { id: "rb", position: { lateralYard: 26.7, absoluteYard: 43 }, shape: "diamond", label: "RB" },
+  { id: "rb", position: { lateralYard: 26.7, absoluteYard: 43 }, shape: "circle", label: "RB" },
   { id: "wr-x", position: { lateralYard: 7, absoluteYard: 49.5 }, shape: "circle", label: "X" },
   { id: "wr-z", position: { lateralYard: 46, absoluteYard: 49.5 }, shape: "circle", label: "Z" },
   { id: "wr-y", position: { lateralYard: 38, absoluteYard: 48 }, shape: "circle", label: "Y" },
-  { id: "te", position: { lateralYard: 33.6, absoluteYard: 49 }, shape: "triangle", label: "TE" },
+  { id: "te", position: { lateralYard: 33.6, absoluteYard: 49 }, shape: "square", label: "TE" },
   {
     id: "dl-1",
     position: { lateralYard: 24.4, absoluteYard: 51 },
-    shape: "pentagon",
+    shape: "circle",
     label: "",
     color: DEFENSE_COLOR,
   },
   {
     id: "dl-2",
     position: { lateralYard: 29, absoluteYard: 51 },
-    shape: "pentagon",
+    shape: "circle",
     label: "",
     color: DEFENSE_COLOR,
   },
   {
     id: "lb-m",
     position: { lateralYard: 26.7, absoluteYard: 54 },
-    shape: "hexagon",
+    shape: "circle",
     label: "M",
     color: DEFENSE_COLOR,
   },
   {
     id: "cb-1",
     position: { lateralYard: 7, absoluteYard: 53 },
-    shape: "hexagon",
+    shape: "circle",
     label: "",
     color: DEFENSE_COLOR,
   },
   {
     id: "cb-2",
     position: { lateralYard: 46, absoluteYard: 53 },
-    shape: "hexagon",
+    shape: "circle",
     label: "",
     color: DEFENSE_COLOR,
   },
   {
     id: "fs",
     position: { lateralYard: 26.7, absoluteYard: 60 },
-    shape: "diamond",
+    shape: "circle",
     label: "FS",
     color: DEFENSE_COLOR,
   },
@@ -152,7 +152,7 @@ const SAMPLE_LINES: Line[] = [
 ];
 
 // 密度ストレス用 fixture。PRD 6.2 を手動目視するため demo に常設し、戦術的厳密さは狙わずに
-// 6 形状・3 線種・straight/bezier・複数 waypoint を 1 ロードで漏れなく確認できる配置にする。
+// 2 形状（丸/四角）・3 線種・straight/bezier・複数 waypoint を 1 ロードで漏れなく確認できる配置にする。
 const STRESS_PLAYERS: Player[] = [
   { id: "ol-c", position: { lateralYard: 26.7, absoluteYard: 49 }, shape: "square", label: "C" },
   { id: "ol-lg", position: { lateralYard: 24.4, absoluteYard: 49 }, shape: "square", label: "LG" },
@@ -160,85 +160,85 @@ const STRESS_PLAYERS: Player[] = [
   { id: "ol-lt", position: { lateralYard: 22.1, absoluteYard: 49 }, shape: "square", label: "LT" },
   { id: "ol-rt", position: { lateralYard: 31.3, absoluteYard: 49 }, shape: "square", label: "RT" },
   { id: "qb", position: { lateralYard: 26.7, absoluteYard: 46.5 }, shape: "circle", label: "QB" },
-  { id: "rb", position: { lateralYard: 26.7, absoluteYard: 43 }, shape: "diamond", label: "RB" },
+  { id: "rb", position: { lateralYard: 26.7, absoluteYard: 43 }, shape: "circle", label: "RB" },
   { id: "wr-x", position: { lateralYard: 7, absoluteYard: 49.5 }, shape: "circle", label: "X" },
   { id: "wr-z", position: { lateralYard: 46, absoluteYard: 49.5 }, shape: "circle", label: "Z" },
   { id: "wr-y", position: { lateralYard: 38, absoluteYard: 48 }, shape: "circle", label: "Y" },
-  { id: "te", position: { lateralYard: 33.6, absoluteYard: 49 }, shape: "triangle", label: "TE" },
+  { id: "te", position: { lateralYard: 33.6, absoluteYard: 49 }, shape: "square", label: "TE" },
   {
     id: "de-l",
     position: { lateralYard: 21.5, absoluteYard: 51 },
-    shape: "pentagon",
+    shape: "circle",
     label: "",
     color: DEFENSE_COLOR,
   },
   {
     id: "dt-l",
     position: { lateralYard: 24.4, absoluteYard: 51 },
-    shape: "pentagon",
+    shape: "circle",
     label: "",
     color: DEFENSE_COLOR,
   },
   {
     id: "dt-r",
     position: { lateralYard: 29, absoluteYard: 51 },
-    shape: "pentagon",
+    shape: "circle",
     label: "",
     color: DEFENSE_COLOR,
   },
   {
     id: "de-r",
     position: { lateralYard: 31.9, absoluteYard: 51 },
-    shape: "pentagon",
+    shape: "circle",
     label: "",
     color: DEFENSE_COLOR,
   },
   {
     id: "lb-w",
     position: { lateralYard: 22, absoluteYard: 54 },
-    shape: "hexagon",
+    shape: "circle",
     label: "W",
     color: DEFENSE_COLOR,
   },
   {
     id: "lb-m",
     position: { lateralYard: 26.7, absoluteYard: 54 },
-    shape: "hexagon",
+    shape: "circle",
     label: "M",
     color: DEFENSE_COLOR,
   },
   {
     id: "lb-s",
     position: { lateralYard: 31.4, absoluteYard: 54 },
-    shape: "hexagon",
+    shape: "circle",
     label: "S",
     color: DEFENSE_COLOR,
   },
   {
     id: "cb-l",
     position: { lateralYard: 7, absoluteYard: 53 },
-    shape: "hexagon",
+    shape: "circle",
     label: "",
     color: DEFENSE_COLOR,
   },
   {
     id: "cb-r",
     position: { lateralYard: 46, absoluteYard: 53 },
-    shape: "hexagon",
+    shape: "circle",
     label: "",
     color: DEFENSE_COLOR,
   },
   {
     id: "fs",
     position: { lateralYard: 24, absoluteYard: 58 },
-    shape: "diamond",
+    shape: "circle",
     label: "FS",
     color: DEFENSE_COLOR,
   },
   {
     id: "ss",
     position: { lateralYard: 30, absoluteYard: 57 },
-    shape: "diamond",
+    shape: "circle",
     label: "SS",
     color: DEFENSE_COLOR,
   },

--- a/src/browser/rendering/canvas-surface.ts
+++ b/src/browser/rendering/canvas-surface.ts
@@ -1,4 +1,5 @@
 import {
+  computeFieldMetrics,
   Disposable,
   type EditorOverlay,
   FieldGeometry,
@@ -137,8 +138,10 @@ export class CanvasSurface extends Disposable {
     read: (name: string, fallback: string) => string,
   ): void {
     const { field, line, player } = this.readThemes(read);
-    this.fieldRenderer.draw(ctx, geometry, field);
-    this.lineRenderer.draw(ctx, geometry, data.lines, data.players, line);
+    // 寸法トークンは W/U から導く純計算。1 フレーム 1 回に束ね、各レンダラへ渡す。
+    const metrics = computeFieldMetrics(geometry.fieldPixelWidth, geometry.scale);
+    this.fieldRenderer.draw(ctx, geometry, field, metrics);
+    this.lineRenderer.draw(ctx, geometry, data.lines, data.players, line, metrics);
     this.playerRenderer.draw(ctx, geometry, data.players, player);
   }
 
@@ -210,18 +213,28 @@ export class CanvasSurface extends Disposable {
   } {
     return {
       field: {
-        fieldColor: read("--playmaker-field-bg", "#2e7d32"),
-        lineColor: read("--playmaker-field-line-color", "rgba(255, 255, 255, 0.85)"),
-        numberColor: read("--playmaker-field-number-color", "rgba(255, 255, 255, 0.9)"),
+        fieldColor: read("--playmaker-field-bg", "#3f7a46"),
+        stripeColor: read("--playmaker-field-stripe", "#3a7341"),
+        oobColor: read("--playmaker-field-oob", "#284b2f"),
+        endzoneColor: read("--playmaker-endzone-bg", "#20503c"),
+        lineColor: read("--playmaker-field-line-color", "rgba(238, 242, 236, 0.9)"),
+        goalLineColor: read("--playmaker-goal-line-color", "#ffffff"),
+        numberColor: read("--playmaker-field-number-color", "rgba(238, 242, 236, 0.9)"),
+        numberFontFamily: read(
+          "--playmaker-number-font-family",
+          '"Arial Narrow", sans-serif-condensed, sans-serif',
+        ),
+        pylonColor: read("--playmaker-pylon-color", "#e8722c"),
+        goalpostColor: read("--playmaker-goalpost-color", "#f3c33a"),
       },
       line: {
-        routeColor: read("--playmaker-line-route-color", "#ffeb3b"),
-        blockColor: read("--playmaker-line-block-color", "#ffffff"),
-        motionColor: read("--playmaker-line-motion-color", "#ffeb3b"),
+        routeColor: read("--playmaker-line-route-color", "#f3c33a"),
+        blockColor: read("--playmaker-line-block-color", "#eef2ec"),
+        motionColor: read("--playmaker-line-motion-color", "#f3c33a"),
       },
       player: {
-        fillColor: read("--playmaker-player-fill", "#1565c0"),
-        strokeColor: read("--playmaker-player-stroke", "rgba(255, 255, 255, 0.9)"),
+        fillColor: read("--playmaker-player-fill", "#1e3fae"),
+        strokeColor: read("--playmaker-player-stroke", "#eef2ec"),
         labelColor: read("--playmaker-player-label-color", "#ffffff"),
       },
     };

--- a/src/browser/rendering/canvas-surface.ts
+++ b/src/browser/rendering/canvas-surface.ts
@@ -95,7 +95,7 @@ export class CanvasSurface extends Disposable {
    * - 出力寸法はフィールド窓のアスペクト比なのでレターボックス余白は出ない。
    */
   exportToPngBlob(data: PlayData, options?: ImageExportOptions): Promise<Blob> {
-    const { width, height } = resolveImageExportSize(options);
+    const { width, height } = resolveImageExportSize(data.field.zone, options);
     const canvas = document.createElement("canvas");
     canvas.width = width;
     canvas.height = height;

--- a/src/browser/rendering/field-renderer.ts
+++ b/src/browser/rendering/field-renderer.ts
@@ -1,37 +1,41 @@
-// フィールド（芝・ヤードライン・ハッシュ・番号）を Canvas へ描く（PRD 5.1）。
-// 座標決定はすべて common の FieldGeometry に委譲し、本クラスは描画命令だけを持つ
-// → 計算ロジックは common 単体テストで網羅し、ここは VRT なしでも薄く保てる。
+// フィールド（芝・刈り込みストライプ・ライン・ハッシュ・数字・エンドゾーン・パイロン・
+// ゴールポスト）を Canvas へ描く（PRD 5.1）。マーキングは実寸比率に忠実、寸法は
+// computeFieldMetrics（common）に集約する＝固定 px を散らさず表示サイズに追従する。
+// 座標決定は FieldGeometry に委譲し、本クラスは描画命令だけを持つ（VRT なしで薄く保つ）。
 
 import {
+  DEFAULT_FIELD_LEAGUE,
   displayYardNumber,
   FIELD_WIDTH_YARDS,
   type FieldGeometry,
-  HASH_FROM_SIDELINE_YARDS,
-  HASH_TICK_YARDS,
+  type FieldMetrics,
+  HASH_CENTER_OFFSET_YARDS_BY_LEAGUE,
   yardLinesInWindow,
 } from "../../common/index.js";
 
 /** 色は CSS 変数（--playmaker-*）由来。商用ソフトが上書きできる（PRD 6.5）。 */
 export interface FieldTheme {
   fieldColor: string;
+  /** 刈り込みストライプの濃い帯（芝ベースとの明度差はごく僅か）。 */
+  stripeColor: string;
+  /** アウトオブバウンズ／レターボックス余白。 */
+  oobColor: string;
+  endzoneColor: string;
   lineColor: string;
+  /** ゴールライン（最重要境界。通常ラインより太く・純白）。 */
+  goalLineColor: string;
   numberColor: string;
+  /** 数字のアスレチック系フォントスタック。 */
+  numberFontFamily: string;
+  pylonColor: string;
+  goalpostColor: string;
 }
 
-// 線の太さ（CSS px）。階層: 外枠 > 10yd > 5yd > 1yd ティック。
-const HEAVY_LINE_WIDTH = 3;
-const MAJOR_LINE_WIDTH = 2;
-const MINOR_LINE_WIDTH = 1.25;
-const TICK_WIDTH = 1;
-
-// 方向マーカー（"9yd マーク"）の寸法（ヤード単位）。数字を主役にするため小ぶり。
+// 数字の方向マーカー（"9yd マーク"相当）の寸法（ヤード）。数字を主役にするため小ぶり。
 const ARROW_LENGTH_YARDS = 0.8;
 const ARROW_HALF_WIDTH_YARDS = 0.3;
-// 数字の中心からゴール側へずらす距離。数字の半分の高さ + 少しのゆとり分。
 const ARROW_OFFSET_FROM_NUMBER_YARDS = 2.5;
-
-const NUMBER_HEIGHT_YARDS = 3.5;
-// 番号の lateralYard。三角も同じ列に置いて縦に揃える。
+// 番号の lateralYard（サイドラインから）。方向三角も同じ列に置いて縦に揃える。
 const NUMBER_FROM_SIDELINE_YARDS = 6;
 
 export class FieldRenderer {
@@ -39,86 +43,189 @@ export class FieldRenderer {
    * geometry の窓に従って 1 フレーム分のフィールドを描く。
    * ctx は CanvasSurface 側で DPR 変換済み（CSS px 空間で描いてよい）。
    */
-  draw(ctx: CanvasRenderingContext2D, geometry: FieldGeometry, theme: FieldTheme): void {
-    const { viewportWidth, viewportHeight, zone } = geometry;
-
-    ctx.fillStyle = theme.fieldColor;
-    ctx.fillRect(0, 0, viewportWidth, viewportHeight);
+  draw(
+    ctx: CanvasRenderingContext2D,
+    geometry: FieldGeometry,
+    theme: FieldTheme,
+    metrics: FieldMetrics,
+  ): void {
+    const { viewportWidth, viewportHeight, window } = geometry;
 
     const left = geometry.xForLateralYard(0);
     const right = geometry.xForLateralYard(FIELD_WIDTH_YARDS);
-    const hashLeft = geometry.xForLateralYard(HASH_FROM_SIDELINE_YARDS);
-    const hashRight = geometry.xForLateralYard(FIELD_WIDTH_YARDS - HASH_FROM_SIDELINE_YARDS);
-    const tickPx = HASH_TICK_YARDS * geometry.scale;
-    const halfTick = tickPx / 2;
-    const centeredTickXs = [hashLeft, hashRight];
+    const top = geometry.yForAbsoluteYard(window.endYard);
+    const bottom = geometry.yForAbsoluteYard(window.startYard);
 
-    // サイドラインのティックだけ内向きに伸ばす（外向きはフィールド外に出てしまう）。
-    // 5yd 倍数は横断ラインと重なるためスキップ。9yd 列は三角マーカーに譲る。
+    // アウトオブバウンズ（レターボックス余白 + サイドライン外）を先に敷く。
+    ctx.fillStyle = theme.oobColor;
+    ctx.fillRect(0, 0, viewportWidth, viewportHeight);
+    // 芝ベース（イン領域）。
+    ctx.fillStyle = theme.fieldColor;
+    ctx.fillRect(left, top, right - left, bottom - top);
+
+    this.drawStripes(ctx, geometry, left, right, theme);
+    this.drawEndZones(ctx, geometry, left, right, theme);
+    this.drawHashes(ctx, geometry, left, right, metrics, theme);
+    this.drawYardLines(ctx, geometry, left, right, top, bottom, metrics, theme);
+    this.drawNumbers(ctx, geometry, metrics, theme);
+    this.drawEndZoneMarkers(ctx, geometry, left, right, metrics, theme);
+  }
+
+  /** 5yd 帯ごとに濃淡を交互にした刈り込みストライプ。EZ(0..100 外)には敷かない。 */
+  private drawStripes(
+    ctx: CanvasRenderingContext2D,
+    geometry: FieldGeometry,
+    left: number,
+    right: number,
+    theme: FieldTheme,
+  ): void {
+    const { startYard, endYard } = geometry.window;
+    const from = Math.max(0, Math.floor(startYard / 5) * 5);
+    const to = Math.min(100, endYard);
+    ctx.fillStyle = theme.stripeColor;
+    for (let band = from; band < to; band += 5) {
+      // 絶対ヤード基準で帯の偶奇を決め、ゾーンを跨いでもストライプ位相を一定に保つ。
+      if ((band / 5) % 2 !== 0) {
+        const yTop = geometry.yForAbsoluteYard(Math.min(band + 5, 100));
+        const yBottom = geometry.yForAbsoluteYard(band);
+        ctx.fillRect(left, yTop, right - left, yBottom - yTop);
+      }
+    }
+  }
+
+  /** エンドゾーン（-10..0 / 100..110）が窓に映る範囲を単色で塗る。内部に線は引かない。 */
+  private drawEndZones(
+    ctx: CanvasRenderingContext2D,
+    geometry: FieldGeometry,
+    left: number,
+    right: number,
+    theme: FieldTheme,
+  ): void {
+    const { startYard, endYard } = geometry.window;
+    ctx.fillStyle = theme.endzoneColor;
+    if (startYard < 0) {
+      const yTop = geometry.yForAbsoluteYard(0);
+      const yBottom = geometry.yForAbsoluteYard(startYard);
+      ctx.fillRect(left, yTop, right - left, yBottom - yTop);
+    }
+    if (endYard > 100) {
+      const yTop = geometry.yForAbsoluteYard(endYard);
+      const yBottom = geometry.yForAbsoluteYard(100);
+      ctx.fillRect(left, yTop, right - left, yBottom - yTop);
+    }
+  }
+
+  /**
+   * ハッシュ（NCAA: 中央 ±0.125W）とサイドライン 1yd 目盛を描く。リーグ表を引くだけで
+   * 切り替えられる。5yd 倍数は横断ラインが覆うため省き、EZ(0..100 外)には引かない。
+   */
+  private drawHashes(
+    ctx: CanvasRenderingContext2D,
+    geometry: FieldGeometry,
+    left: number,
+    right: number,
+    metrics: FieldMetrics,
+    theme: FieldTheme,
+  ): void {
+    const offset = HASH_CENTER_OFFSET_YARDS_BY_LEAGUE[DEFAULT_FIELD_LEAGUE];
+    const center = FIELD_WIDTH_YARDS / 2;
+    const hashLeft = geometry.xForLateralYard(center - offset);
+    const hashRight = geometry.xForLateralYard(center + offset);
+    const tick = metrics.hashTickLength;
+    const half = tick / 2;
+
     ctx.strokeStyle = theme.lineColor;
-    ctx.lineWidth = TICK_WIDTH;
+    ctx.lineWidth = metrics.yardLineWidth;
     ctx.beginPath();
-    for (const yard of yardLinesInWindow(zone, 1)) {
-      if (yard % 5 === 0) {
+    for (const yard of yardLinesInWindow(geometry.zone, 1)) {
+      if (yard < 0 || yard > 100 || yard % 5 === 0) {
         continue;
       }
       const y = geometry.yForAbsoluteYard(yard);
       ctx.moveTo(left, y);
-      ctx.lineTo(left + tickPx, y);
-      ctx.moveTo(right - tickPx, y);
+      ctx.lineTo(left + tick, y);
+      ctx.moveTo(right - tick, y);
       ctx.lineTo(right, y);
-      for (const cx of centeredTickXs) {
-        ctx.moveTo(cx - halfTick, y);
-        ctx.lineTo(cx + halfTick, y);
-      }
+      ctx.moveTo(hashLeft - half, y);
+      ctx.lineTo(hashLeft + half, y);
+      ctx.moveTo(hashRight - half, y);
+      ctx.lineTo(hashRight + half, y);
     }
     ctx.stroke();
+  }
 
-    // 太さ階層ごとに 1 ストロークへ集約（lineWidth 変更はストローク確定のため）。
+  /**
+   * 5yd ヤードライン（0..100）と境界ボックスを太さ階層で描く。
+   * 階層: ゴールライン(別色・最太) > センター/境界(気持ち太め) > 通常 5yd。
+   */
+  private drawYardLines(
+    ctx: CanvasRenderingContext2D,
+    geometry: FieldGeometry,
+    left: number,
+    right: number,
+    top: number,
+    bottom: number,
+    metrics: FieldMetrics,
+    theme: FieldTheme,
+  ): void {
     const goalPath = new Path2D();
-    const majorPath = new Path2D();
+    const midPath = new Path2D();
     const minorPath = new Path2D();
-    for (const yard of yardLinesInWindow(zone, 5)) {
+    for (const yard of yardLinesInWindow(geometry.zone, 5)) {
+      if (yard < 0 || yard > 100) {
+        continue;
+      }
       const y = geometry.yForAbsoluteYard(yard);
-      const target =
-        yard === 0 || yard === 100 ? goalPath : yard % 10 === 0 ? majorPath : minorPath;
+      const target = yard === 0 || yard === 100 ? goalPath : yard === 50 ? midPath : minorPath;
       target.moveTo(left, y);
       target.lineTo(right, y);
     }
-    ctx.lineWidth = MINOR_LINE_WIDTH;
-    ctx.stroke(minorPath);
-    ctx.lineWidth = MAJOR_LINE_WIDTH;
-    ctx.stroke(majorPath);
-    ctx.lineWidth = HEAVY_LINE_WIDTH;
-    ctx.stroke(goalPath);
 
-    const top = geometry.yForAbsoluteYard(geometry.window.endYard);
-    const bottom = geometry.yForAbsoluteYard(geometry.window.startYard);
+    ctx.strokeStyle = theme.lineColor;
+    ctx.lineWidth = metrics.yardLineWidth;
+    ctx.stroke(minorPath);
+    ctx.lineWidth = 1.5 * metrics.yardLineWidth;
+    ctx.stroke(midPath);
+
+    // 境界ボックス（サイドライン + 窓上下端）。境界も気持ち太め。
+    ctx.lineWidth = metrics.goalLineWidth;
     ctx.beginPath();
     ctx.moveTo(left, top);
     ctx.lineTo(left, bottom);
     ctx.moveTo(right, top);
     ctx.lineTo(right, bottom);
+    ctx.moveTo(left, top);
+    ctx.lineTo(right, top);
+    ctx.moveTo(left, bottom);
+    ctx.lineTo(right, bottom);
     ctx.stroke();
 
-    // 番号付きヤードライン（10yd 刻み）ごとに、数字と「数字の隣の三角」を描く。
-    // 三角は数字からゴール側へ ARROW_OFFSET_FROM_NUMBER_YARDS ずれた位置に置き、
-    // 5yd ラインの上に正確に乗らずに数字とペアで読めるようにする。
-    // ゴール(0)・センター(50)は数字のみ。
-    // 三角は数字と同じ lateralYard 列に揃えて縦に並べる。
-    const arrowLeftX = geometry.xForLateralYard(NUMBER_FROM_SIDELINE_YARDS);
-    const arrowRightX = geometry.xForLateralYard(FIELD_WIDTH_YARDS - NUMBER_FROM_SIDELINE_YARDS);
+    // ゴールラインは最重要境界として最も目立たせる（別色・最太）。
+    ctx.strokeStyle = theme.goalLineColor;
+    ctx.lineWidth = metrics.goalLineWidth;
+    ctx.stroke(goalPath);
+  }
+
+  /**
+   * 番号付きヤードライン（10yd 刻み）に数字と方向三角を描く。数字は上下ミラーで
+   * 両サイドラインから読め、三角は最寄りゴール方向。EZ・ゴール(0)・センター(50)は
+   * 数字/三角の扱いを分ける（displayYardNumber が 0 を返す EZ は描かない）。
+   */
+  private drawNumbers(
+    ctx: CanvasRenderingContext2D,
+    geometry: FieldGeometry,
+    metrics: FieldMetrics,
+    theme: FieldTheme,
+  ): void {
+    const leftX = geometry.xForLateralYard(NUMBER_FROM_SIDELINE_YARDS);
+    const rightX = geometry.xForLateralYard(FIELD_WIDTH_YARDS - NUMBER_FROM_SIDELINE_YARDS);
     const arrowBaseHalfPx = ARROW_HALF_WIDTH_YARDS * geometry.scale;
     const halfArrowLength = ARROW_LENGTH_YARDS / 2;
 
-    const fontPx = Math.max(10, NUMBER_HEIGHT_YARDS * geometry.scale);
-    // Canvas の ctx.font は CSS の var() を解釈できず "10px sans-serif" にフォールバックする
-    // ため、--playmaker-font-family を埋め込まず固定スタックを書く。
-    ctx.font = `600 ${fontPx}px system-ui, sans-serif`;
+    // Canvas の ctx.font は CSS var() を解釈できないため、テーマから読んだ実体スタックを書く。
+    ctx.font = `600 ${metrics.numberHeight}px ${theme.numberFontFamily}`;
     ctx.textBaseline = "middle";
     ctx.textAlign = "center";
-    const leftNumberX = geometry.xForLateralYard(NUMBER_FROM_SIDELINE_YARDS);
-    const rightNumberX = geometry.xForLateralYard(FIELD_WIDTH_YARDS - NUMBER_FROM_SIDELINE_YARDS);
 
     const drawRotatedLabel = (label: string, x: number, y: number, rotation: number): void => {
       ctx.save();
@@ -136,17 +243,15 @@ export class FieldRenderer {
       ctx.fill();
     };
 
-    for (const yard of yardLinesInWindow(zone, 10)) {
+    for (const yard of yardLinesInWindow(geometry.zone, 10)) {
       const n = displayYardNumber(yard);
       if (n === 0) {
         continue;
       }
-      const label = String(n);
       const numberY = geometry.yForAbsoluteYard(yard);
-
       ctx.fillStyle = theme.numberColor;
-      drawRotatedLabel(label, leftNumberX, numberY, Math.PI / 2);
-      drawRotatedLabel(label, rightNumberX, numberY, -Math.PI / 2);
+      drawRotatedLabel(String(n), leftX, numberY, Math.PI / 2);
+      drawRotatedLabel(String(n), rightX, numberY, -Math.PI / 2);
 
       if (yard === 50) {
         continue;
@@ -156,8 +261,75 @@ export class FieldRenderer {
       const tipY = geometry.yForAbsoluteYard(arrowCenterYard + towardGoal * halfArrowLength);
       const baseY = geometry.yForAbsoluteYard(arrowCenterYard - towardGoal * halfArrowLength);
       ctx.fillStyle = theme.lineColor;
-      drawArrow(arrowLeftX, tipY, baseY);
-      drawArrow(arrowRightX, tipY, baseY);
+      drawArrow(leftX, tipY, baseY);
+      drawArrow(rightX, tipY, baseY);
     }
+  }
+
+  /** エンドゾーンの 4 隅にパイロン、エンドライン中央にゴールポストを描く。 */
+  private drawEndZoneMarkers(
+    ctx: CanvasRenderingContext2D,
+    geometry: FieldGeometry,
+    left: number,
+    right: number,
+    metrics: FieldMetrics,
+    theme: FieldTheme,
+  ): void {
+    const { startYard, endYard } = geometry.window;
+    const pylon = Math.max(3, 0.45 * geometry.scale);
+    const drawPylon = (x: number, y: number): void => {
+      ctx.fillStyle = theme.pylonColor;
+      ctx.fillRect(x - pylon / 2, y - pylon / 2, pylon, pylon);
+    };
+
+    if (startYard < 0) {
+      const goalY = geometry.yForAbsoluteYard(0);
+      const endY = geometry.yForAbsoluteYard(startYard);
+      drawPylon(left, goalY);
+      drawPylon(right, goalY);
+      drawPylon(left, endY);
+      drawPylon(right, endY);
+      // 自陣 EZ は画面下。ゴールポストの開き（uprights）はフィールド側（上＝-y）へ。
+      this.drawGoalpost(ctx, geometry, endY, -1, metrics, theme);
+    }
+    if (endYard > 100) {
+      const goalY = geometry.yForAbsoluteYard(100);
+      const endY = geometry.yForAbsoluteYard(endYard);
+      drawPylon(left, goalY);
+      drawPylon(right, goalY);
+      drawPylon(left, endY);
+      drawPylon(right, endY);
+      // 相手 EZ は画面上。uprights はフィールド側（下＝+y）へ。
+      this.drawGoalpost(ctx, geometry, endY, 1, metrics, theme);
+    }
+  }
+
+  /** エンドライン中央のゴールポスト（crossbar + 2 本の uprights）。dir はフィールド方向の符号。 */
+  private drawGoalpost(
+    ctx: CanvasRenderingContext2D,
+    geometry: FieldGeometry,
+    lineY: number,
+    dir: 1 | -1,
+    metrics: FieldMetrics,
+    theme: FieldTheme,
+  ): void {
+    const cx = geometry.xForLateralYard(FIELD_WIDTH_YARDS / 2);
+    const u = geometry.scale;
+    const crossHalf = 1.85 * u;
+    const uprightLen = 1.2 * u;
+
+    ctx.save();
+    ctx.strokeStyle = theme.goalpostColor;
+    ctx.lineWidth = Math.max(2, 0.2 * metrics.tokenDiameter);
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    ctx.moveTo(cx - crossHalf, lineY);
+    ctx.lineTo(cx + crossHalf, lineY);
+    ctx.moveTo(cx - crossHalf, lineY);
+    ctx.lineTo(cx - crossHalf, lineY + dir * uprightLen);
+    ctx.moveTo(cx + crossHalf, lineY);
+    ctx.lineTo(cx + crossHalf, lineY + dir * uprightLen);
+    ctx.stroke();
+    ctx.restore();
   }
 }

--- a/src/browser/rendering/line-renderer.ts
+++ b/src/browser/rendering/line-renderer.ts
@@ -1,11 +1,11 @@
-// 線（route / block / motion）を Canvas へ描く（PRD 5.3）。
-// 線の幾何（起点選手の解決・waypoint 連結・曲線サンプル）はすべて common に委譲し、
-// 本クラスは「サンプル後ポリラインを種別ごとの見た目で描く」命令だけを持つ
-// → ロジックは common 単体テストで網羅、ここは VRT なしでも薄く保てる。
-// 戦術記法準拠の体裁（block の T 字終端等）は意図的にスコープ外（PRD 4.1 で表現範囲を絞る）。
+// 線（route / block / motion）を Canvas へ描く（PRD 5.3）。動作ごとに記法を変える:
+// route/motion = 塗り三角の矢印、block = 直角バー（T 字キャップ）。色でなく記法で区別する。
+// 線の幾何（起点選手の解決・waypoint 連結・曲線サンプル）と寸法トークンは common に委譲し、
+// 本クラスは「サンプル後ポリラインを種別ごとの見た目で描く」命令だけを持つ（VRT なしで薄く保つ）。
 
 import {
   type FieldGeometry,
+  type FieldMetrics,
   indexPlayersById,
   type Line,
   type LineKind,
@@ -21,17 +21,10 @@ export interface LineTheme {
   motionColor: string;
 }
 
-// 既定の線幅（CSS px）。block を太く、route/motion は標準。line.thickness で上書き可。
-const DEFAULT_WIDTH_PX: Record<LineKind, number> = {
-  route: 2.5,
-  block: 5,
-  motion: 2.5,
-};
-
-// 矢印・破線はヤード基準でスケールし、ビューポートに依らず比率を一定に保つ。
-const ARROW_LENGTH_YARDS = 1.4;
-const ARROW_HALF_WIDTH_YARDS = 0.9;
-const MOTION_DASH_YARDS: readonly [number, number] = [1.2, 0.8];
+interface CanvasPoint {
+  x: number;
+  y: number;
+}
 
 export class LineRenderer {
   /**
@@ -44,6 +37,7 @@ export class LineRenderer {
     lines: readonly Line[],
     players: readonly Player[],
     theme: LineTheme,
+    metrics: FieldMetrics,
   ): void {
     if (geometry.scale <= 0 || lines.length === 0) {
       return;
@@ -63,7 +57,7 @@ export class LineRenderer {
       }
 
       const color = line.color ?? this.colorFor(line.kind, theme);
-      const width = line.thickness ?? DEFAULT_WIDTH_PX[line.kind];
+      const width = line.thickness ?? this.widthFor(line.kind, metrics);
 
       ctx.save();
       ctx.strokeStyle = color;
@@ -71,21 +65,24 @@ export class LineRenderer {
       ctx.lineJoin = "round";
       ctx.lineCap = "round";
       if (line.kind === "motion") {
-        ctx.setLineDash(MOTION_DASH_YARDS.map((d) => d * geometry.scale));
+        ctx.setLineDash([...metrics.motionDash]);
       }
 
       ctx.beginPath();
-      const head = path[0] as { x: number; y: number };
+      const head = path[0] as CanvasPoint;
       ctx.moveTo(head.x, head.y);
       for (let i = 1; i < path.length; i++) {
-        const pt = path[i] as { x: number; y: number };
+        const pt = path[i] as CanvasPoint;
         ctx.lineTo(pt.x, pt.y);
       }
       ctx.stroke();
+      ctx.setLineDash([]);
 
-      // route だけ終点に矢印（PRD 5.3）。block/motion は矢印なし。
-      if (line.kind === "route") {
-        this.drawArrowHead(ctx, path, color, geometry.scale);
+      // 記法で区別: 走路は矢印、ブロックは T 字キャップ。
+      if (line.kind === "block") {
+        this.drawBlockCap(ctx, path, color, metrics, width);
+      } else {
+        this.drawArrowHead(ctx, path, color, metrics);
       }
       ctx.restore();
     }
@@ -102,41 +99,75 @@ export class LineRenderer {
     }
   }
 
-  /** 終点に、最後の進行方向へ向けた塗り三角の矢じりを描く。 */
-  private drawArrowHead(
-    ctx: CanvasRenderingContext2D,
-    path: readonly { x: number; y: number }[],
-    color: string,
-    scale: number,
-  ): void {
-    const tip = path[path.length - 1] as { x: number; y: number };
-    // 終点と一致しない直近点を遡って進行方向を得る（曲線末尾の微小区間対策）。
-    let prev: { x: number; y: number } | undefined;
+  /** block は route と同じ太さ。記法（T 字）で区別するため色・太さに頼らない。 */
+  private widthFor(kind: LineKind, metrics: FieldMetrics): number {
+    return kind === "block" ? metrics.blockWidth : metrics.routeWidth;
+  }
+
+  /**
+   * 終点と一致しない直近点を遡り、終端の進行方向（角度）を得る。
+   * 曲線末尾の微小区間で方向が出ない事故を避ける。終端飾りの共通前処理。
+   */
+  private endAngle(path: readonly CanvasPoint[]): number | undefined {
+    const tip = path[path.length - 1] as CanvasPoint;
     for (let i = path.length - 2; i >= 0; i--) {
-      const p = path[i] as { x: number; y: number };
+      const p = path[i] as CanvasPoint;
       if (p.x !== tip.x || p.y !== tip.y) {
-        prev = p;
-        break;
+        return Math.atan2(tip.y - p.y, tip.x - p.x);
       }
     }
-    if (prev === undefined) {
+    return undefined;
+  }
+
+  /** 終点に、進行方向へ向けた塗り三角の矢じりを描く（route / motion）。 */
+  private drawArrowHead(
+    ctx: CanvasRenderingContext2D,
+    path: readonly CanvasPoint[],
+    color: string,
+    metrics: FieldMetrics,
+  ): void {
+    const angle = this.endAngle(path);
+    if (angle === undefined) {
       return;
     }
-    const angle = Math.atan2(tip.y - prev.y, tip.x - prev.x);
-    const len = ARROW_LENGTH_YARDS * scale;
-    const half = ARROW_HALF_WIDTH_YARDS * scale;
-    const baseX = tip.x - len * Math.cos(angle);
-    const baseY = tip.y - len * Math.sin(angle);
+    const tip = path[path.length - 1] as CanvasPoint;
+    const baseX = tip.x - metrics.arrowLength * Math.cos(angle);
+    const baseY = tip.y - metrics.arrowLength * Math.sin(angle);
     const nx = -Math.sin(angle);
     const ny = Math.cos(angle);
 
-    ctx.setLineDash([]);
     ctx.beginPath();
     ctx.moveTo(tip.x, tip.y);
-    ctx.lineTo(baseX + half * nx, baseY + half * ny);
-    ctx.lineTo(baseX - half * nx, baseY - half * ny);
+    ctx.lineTo(baseX + metrics.arrowHalfWidth * nx, baseY + metrics.arrowHalfWidth * ny);
+    ctx.lineTo(baseX - metrics.arrowHalfWidth * nx, baseY - metrics.arrowHalfWidth * ny);
     ctx.closePath();
     ctx.fillStyle = color;
     ctx.fill();
+  }
+
+  /** 終点に、進行方向と直交する T 字バーを描く（block）。矢印と一目で見分けるため。 */
+  private drawBlockCap(
+    ctx: CanvasRenderingContext2D,
+    path: readonly CanvasPoint[],
+    color: string,
+    metrics: FieldMetrics,
+    width: number,
+  ): void {
+    const angle = this.endAngle(path);
+    if (angle === undefined) {
+      return;
+    }
+    const tip = path[path.length - 1] as CanvasPoint;
+    const nx = -Math.sin(angle);
+    const ny = Math.cos(angle);
+    const half = metrics.blockCapLength / 2;
+
+    ctx.beginPath();
+    ctx.strokeStyle = color;
+    ctx.lineWidth = width * 1.2;
+    ctx.lineCap = "round";
+    ctx.moveTo(tip.x - half * nx, tip.y - half * ny);
+    ctx.lineTo(tip.x + half * nx, tip.y + half * ny);
+    ctx.stroke();
   }
 }

--- a/src/browser/rendering/player-renderer.ts
+++ b/src/browser/rendering/player-renderer.ts
@@ -57,10 +57,14 @@ export class PlayerRenderer {
     }
     // ラベルは選手マーカーの中に収まるサイズに抑える（半径の 1/3 ほど）。
     const fontPx = Math.max(8, r * 0.35);
+    // 芝から浮かせる白フチ + ごく弱い影。影を強くするとダサくなるので控えめに。
+    const shadowBlur = Math.max(2, r * 0.18);
+    const shadowOffset = Math.max(1, r * 0.08);
 
     for (const player of players) {
       const { x, y } = geometry.toCanvas(player.position.lateralYard, player.position.absoluteYard);
 
+      ctx.save();
       ctx.beginPath();
       if (player.shape === "circle") {
         ctx.arc(x, y, r, 0, Math.PI * 2);
@@ -68,11 +72,20 @@ export class PlayerRenderer {
         this.tracePolygon(ctx, x, y, r, player.shape);
       }
 
+      // 影は塗りにだけ載せる（フチ/ラベルへ二重に乗らないよう塗り直後に解除）。
+      ctx.shadowColor = "rgba(0, 0, 0, 0.4)";
+      ctx.shadowBlur = shadowBlur;
+      ctx.shadowOffsetY = shadowOffset;
       ctx.fillStyle = player.color ?? theme.fillColor;
       ctx.fill();
+      ctx.shadowColor = "transparent";
+      ctx.shadowBlur = 0;
+      ctx.shadowOffsetY = 0;
+
       ctx.lineWidth = STROKE_WIDTH;
       ctx.strokeStyle = theme.strokeColor;
       ctx.stroke();
+      ctx.restore();
 
       if (player.label !== "") {
         ctx.fillStyle = theme.labelColor;

--- a/src/browser/ui/property-panel.ts
+++ b/src/browser/ui/property-panel.ts
@@ -11,7 +11,9 @@ import {
   toDisposable,
 } from "../../common/index.js";
 
-const SHAPES: PlayerShape[] = ["circle", "square", "triangle", "diamond", "pentagon", "hexagon"];
+// 形状の語彙は 2 種に絞る（丸=スキル系、四角=ライン系）。多種混在は図を散らかす。
+// 旧データが持つ他形状はモデル・レンダラ側で引き続き受理する（描画の後方互換）。
+const SHAPES: PlayerShape[] = ["circle", "square"];
 const KINDS: LineKind[] = ["route", "block", "motion"];
 const INTERPOLATIONS: LineInterpolation[] = ["straight", "bezier"];
 
@@ -126,7 +128,7 @@ export class PropertyPanel extends Disposable {
   ): void {
     const input = document.createElement("input");
     input.type = "color";
-    input.value = toHex(value, "#1565c0");
+    input.value = toHex(value, "#1e3fae");
     input.addEventListener("change", () => onChange(input.value));
     this.addRow(labelText, input);
   }

--- a/src/common/design/metrics.test.ts
+++ b/src/common/design/metrics.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { PLAYER_RADIUS_YARDS } from "../model/player.js";
+import { computeFieldMetrics } from "./metrics.js";
+
+describe("computeFieldMetrics", () => {
+  it("通常サイズで W/U 比率から各寸法を導く", () => {
+    const W = 580;
+    const U = 10.875;
+    const m = computeFieldMetrics(W, U);
+    const D = 2 * PLAYER_RADIUS_YARDS * U;
+
+    expect(m.yardLineWidth).toBeCloseTo(0.0021 * W);
+    expect(m.goalLineWidth).toBeCloseTo(2 * 0.0021 * W);
+    expect(m.hashTickLength).toBeCloseTo(0.375 * U);
+    expect(m.numberHeight).toBeCloseTo(2.4 * U);
+    expect(m.tokenDiameter).toBeCloseTo(D);
+    expect(m.routeWidth).toBeCloseTo(0.11 * D);
+    expect(m.blockWidth).toBeCloseTo(m.routeWidth);
+    expect(m.blockCapLength).toBeCloseTo(0.4 * D);
+    expect(m.arrowLength).toBeCloseTo(D);
+    expect(m.arrowHalfWidth).toBeCloseTo(0.62 * D);
+    expect(m.motionDash[0]).toBeCloseTo(1.1 * U);
+    expect(m.motionDash[1]).toBeCloseTo(0.7 * U);
+  });
+
+  it("ゴールラインは通常ヤードラインの 2 倍", () => {
+    const m = computeFieldMetrics(580, 10.875);
+    expect(m.goalLineWidth).toBeCloseTo(2 * m.yardLineWidth);
+  });
+
+  it("極小フィールドでは最小値（ライン 1px・数字 10px・線 1.5px）に張り付く", () => {
+    const m = computeFieldMetrics(100, 1.875);
+    expect(m.yardLineWidth).toBe(1);
+    expect(m.numberHeight).toBe(10);
+    expect(m.routeWidth).toBe(1.5);
+    expect(m.blockWidth).toBe(1.5);
+  });
+
+  it("縮退ビューポート（0）でも NaN を返さず最小値へ丸める", () => {
+    const m = computeFieldMetrics(0, 0);
+    expect(m.yardLineWidth).toBe(1);
+    expect(m.goalLineWidth).toBe(2);
+    expect(m.hashTickLength).toBe(0);
+    expect(m.numberHeight).toBe(10);
+    expect(m.tokenDiameter).toBe(0);
+    expect(m.routeWidth).toBe(1.5);
+    expect(m.arrowLength).toBe(0);
+    expect(m.motionDash).toEqual([0, 0]);
+  });
+
+  it("負の入力は 0 として扱う", () => {
+    const m = computeFieldMetrics(-10, -5);
+    expect(m.yardLineWidth).toBe(1);
+    expect(m.hashTickLength).toBe(0);
+    expect(m.tokenDiameter).toBe(0);
+  });
+});

--- a/src/common/design/metrics.ts
+++ b/src/common/design/metrics.ts
@@ -1,0 +1,73 @@
+// フィールド描画の寸法トークン。固定 px を散らさず、フィールド幅 W(px) と
+// 1 ヤード U(px) から比率で算出する＝表示サイズ・ゾーン・端末が変わっても破綻しない。
+// DOM 非依存の純計算（VSCode 流 common）。色は CSS 変数側に集約し、ここは寸法のみ。
+//
+// 2 つの層で基準が違う:
+//  - マーキング層（ライン・数字・ハッシュ）: 実寸比率に忠実（W/U 基準）。本物らしさを決める。
+//  - 注釈層（選手トークン・プレー線）: 視認性優先で 1 基準直径 D から派生。実寸より誇張してよい。
+// D は実マーカー直径（= 2·PLAYER_RADIUS_YARDS·U）を採用する。レンダラの描画半径と
+// hit-test 半径が一致する不変条件（player.ts）を保つため、トークンはヤード基準を維持し、
+// プレー線・矢印・T 字キャップをこの D 比で揃える。
+
+import { PLAYER_RADIUS_YARDS } from "../model/player.js";
+
+// マーキング層（実寸比率）。
+const MIN_LINE_PX = 1; // 細いラインでも 1px は確保し消えないようにする。
+const YARD_LINE_WIDTH_PER_W = 0.0021; // 実寸 4in / 160ft。
+const HASH_TICK_LENGTH_PER_U = 0.375; // 実寸 24in を U 比で。
+const NUMBER_HEIGHT_PER_U = 2.4; // 実寸 6ft(=2yd) を視認用に拡大（2.3〜2.6U の範囲内）。
+const NUMBER_MIN_PX = 10;
+
+// 注釈層（D 基準・視認性優先）。
+const ROUTE_WIDTH_PER_D = 0.11;
+const ROUTE_WIDTH_MIN_PX = 1.5;
+const BLOCK_CAP_LENGTH_PER_D = 0.4; // T 字キャップ長。ルート矢印と一目で見分く大きさ。
+const ARROW_LENGTH_PER_D = 1.0;
+const ARROW_HALF_WIDTH_PER_D = 0.62;
+const MOTION_DASH_ON_PER_U = 1.1;
+const MOTION_DASH_OFF_PER_U = 0.7;
+
+/** W(フィールド幅px)・U(1ヤードpx) から導く描画寸法（px）。 */
+export interface FieldMetrics {
+  /** マーキング層。 */
+  yardLineWidth: number;
+  /** ゴールライン・境界は最重要なので通常ラインの 2 倍。 */
+  goalLineWidth: number;
+  hashTickLength: number;
+  numberHeight: number;
+  /** 注釈層の基準直径 D（実マーカー直径）。 */
+  tokenDiameter: number;
+  routeWidth: number;
+  /** block も route と同じ太さ。記法（T 字）で区別する。 */
+  blockWidth: number;
+  blockCapLength: number;
+  arrowLength: number;
+  arrowHalfWidth: number;
+  /** モーション破線パターン [on, off]（px）。 */
+  motionDash: readonly [number, number];
+}
+
+/**
+ * フィールド幅 W と 1 ヤード U（= geometry.scale）から描画寸法トークンを導く。
+ * 縮退ビューポート（W=U=0）でもラインは MIN_LINE_PX を返し NaN を流さない。
+ */
+export function computeFieldMetrics(fieldPixelWidth: number, unitPx: number): FieldMetrics {
+  const w = Math.max(0, fieldPixelWidth);
+  const u = Math.max(0, unitPx);
+  const yardLineWidth = Math.max(MIN_LINE_PX, YARD_LINE_WIDTH_PER_W * w);
+  const d = 2 * PLAYER_RADIUS_YARDS * u;
+  const routeWidth = Math.max(ROUTE_WIDTH_MIN_PX, ROUTE_WIDTH_PER_D * d);
+  return {
+    yardLineWidth,
+    goalLineWidth: 2 * yardLineWidth,
+    hashTickLength: HASH_TICK_LENGTH_PER_U * u,
+    numberHeight: Math.max(NUMBER_MIN_PX, NUMBER_HEIGHT_PER_U * u),
+    tokenDiameter: d,
+    routeWidth,
+    blockWidth: routeWidth,
+    blockCapLength: BLOCK_CAP_LENGTH_PER_D * d,
+    arrowLength: ARROW_LENGTH_PER_D * d,
+    arrowHalfWidth: ARROW_HALF_WIDTH_PER_D * d,
+    motionDash: [MOTION_DASH_ON_PER_U * u, MOTION_DASH_OFF_PER_U * u],
+  };
+}

--- a/src/common/export/image-export.test.ts
+++ b/src/common/export/image-export.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { FIELD_WIDTH_YARDS, ZONE_WINDOW_LENGTH_YARDS } from "../geometry/field.js";
+import { FIELD_WIDTH_YARDS, zoneWindowLength } from "../geometry/field.js";
 import {
   DEFAULT_EXPORT_WIDTH,
-  FIELD_WINDOW_ASPECT,
+  fieldWindowAspect,
   type ImageExportOptions,
   resolveImageExportSize,
   resolveImageExportWidth,
 } from "./image-export.js";
 
-describe("FIELD_WINDOW_ASPECT", () => {
-  it("フィールド窓（幅 / 縦 30yd）の比に一致する", () => {
-    expect(FIELD_WINDOW_ASPECT).toBe(FIELD_WIDTH_YARDS / ZONE_WINDOW_LENGTH_YARDS);
+describe("fieldWindowAspect", () => {
+  it("各ゾーンの窓（幅 / 縦＝ゾーン窓長）の比に一致する", () => {
+    expect(fieldWindowAspect("middle")).toBe(FIELD_WIDTH_YARDS / zoneWindowLength("middle"));
+    expect(fieldWindowAspect("redzone")).toBe(FIELD_WIDTH_YARDS / zoneWindowLength("redzone"));
+  });
+
+  it("縦長なレッドゾーン窓は middle より横長比が小さい", () => {
+    expect(fieldWindowAspect("redzone")).toBeLessThan(fieldWindowAspect("middle"));
   });
 });
 
@@ -44,31 +49,38 @@ describe("resolveImageExportWidth", () => {
 });
 
 describe("resolveImageExportSize", () => {
-  it("幅指定なし（引数省略）なら既定幅とアスペクト比由来の高さを返す", () => {
-    const size = resolveImageExportSize();
+  it("幅指定なし（省略）なら既定幅とゾーン窓のアスペクト比由来の高さを返す", () => {
+    const size = resolveImageExportSize("middle");
 
     expect(size.width).toBe(DEFAULT_EXPORT_WIDTH);
-    expect(size.height).toBe(Math.round(DEFAULT_EXPORT_WIDTH / FIELD_WINDOW_ASPECT));
+    expect(size.height).toBe(Math.round(DEFAULT_EXPORT_WIDTH / fieldWindowAspect("middle")));
   });
 
-  it("指定幅からフィールド窓のアスペクト比で高さを導く", () => {
-    const size = resolveImageExportSize({ width: 1777 });
+  it("指定幅からゾーン窓のアスペクト比で高さを導く", () => {
+    const size = resolveImageExportSize("middle", { width: 1777 });
 
     expect(size.width).toBe(1777);
-    expect(size.height).toBe(Math.round(1777 / FIELD_WINDOW_ASPECT));
+    expect(size.height).toBe(Math.round(1777 / fieldWindowAspect("middle")));
+  });
+
+  it("縦長なレッドゾーン窓は同じ幅でも高さが大きくなる", () => {
+    const middle = resolveImageExportSize("middle", { width: 1600 });
+    const redzone = resolveImageExportSize("redzone", { width: 1600 });
+
+    expect(redzone.height).toBeGreaterThan(middle.height);
   });
 
   it("不正な幅は既定へ丸めたうえで高さを導く", () => {
     const options: ImageExportOptions = { width: -1 };
 
-    const size = resolveImageExportSize(options);
+    const size = resolveImageExportSize("redzone", options);
 
     expect(size.width).toBe(DEFAULT_EXPORT_WIDTH);
-    expect(size.height).toBe(Math.round(DEFAULT_EXPORT_WIDTH / FIELD_WINDOW_ASPECT));
+    expect(size.height).toBe(Math.round(DEFAULT_EXPORT_WIDTH / fieldWindowAspect("redzone")));
   });
 
   it("最小幅 1 でも高さは 1 以上になる", () => {
-    const size = resolveImageExportSize({ width: 1 });
+    const size = resolveImageExportSize("middle", { width: 1 });
 
     expect(size.width).toBe(1);
     expect(size.height).toBeGreaterThanOrEqual(1);

--- a/src/common/export/image-export.ts
+++ b/src/common/export/image-export.ts
@@ -6,22 +6,25 @@
 // 外部受け入れの作法は resolvePlayData / normalizeFormation と揃える：
 // 公開境界で不正値を既定へ丸め、復元不能なら投げずに安全側へ倒す（PRD 6.6 流）。
 
-import { FIELD_WIDTH_YARDS, ZONE_WINDOW_LENGTH_YARDS } from "../geometry/field.js";
+import { FIELD_WIDTH_YARDS, zoneWindowLength } from "../geometry/field.js";
+import type { FieldZone } from "../model/play-data.js";
 
 /**
- * フィールド窓（幅 FIELD_WIDTH_YARDS × 縦 30yd）のアスペクト比。
- * ゾーンに依らず常に一定（どのゾーンも窓の縦は ZONE_WINDOW_LENGTH_YARDS）。
- * 出力高さをこの比から導けば、エクスポート画像はレターボックス余白なしで
- * フィールド窓ぴったりになる（FieldGeometry の offset がほぼ 0 になる）。
+ * フィールド窓（幅 FIELD_WIDTH_YARDS × 縦＝ゾーン窓長）のアスペクト比。
+ * レッドゾーン窓は middle より縦長なのでゾーンごとに異なる。出力高さをこの比から
+ * 導けば、エクスポート画像はレターボックス余白なしでフィールド窓ぴったりになる
+ * （FieldGeometry の offset がほぼ 0 になる）。
  */
-export const FIELD_WINDOW_ASPECT = FIELD_WIDTH_YARDS / ZONE_WINDOW_LENGTH_YARDS;
+export function fieldWindowAspect(zone: FieldZone): number {
+  return FIELD_WIDTH_YARDS / zoneWindowLength(zone);
+}
 
 /** width 未指定/不正時の既定出力幅(px)。組み込み先が十分な解像度を得られる目安。 */
 export const DEFAULT_EXPORT_WIDTH = 1600;
 
 export interface ImageExportOptions {
   /**
-   * 出力 PNG の横幅(px)。高さはフィールド窓のアスペクト比から導く。
+   * 出力 PNG の横幅(px)。高さはゾーン窓のアスペクト比から導く。
    * 未指定・非有限・1 未満は DEFAULT_EXPORT_WIDTH に丸める（外部入力の防御）。
    */
   width?: number;
@@ -40,11 +43,14 @@ export function resolveImageExportWidth(width: number | undefined): number {
 }
 
 /**
- * エクスポート設定 → 出力ピクセル寸法。幅は正規化し、高さはフィールド窓の
+ * エクスポート設定 → 出力ピクセル寸法。幅は正規化し、高さはゾーン窓の
  * アスペクト比から導く。width >= 1 なので height も必ず 1 以上になる
  * （冗長な下限ガードは置かない＝common 100% を素直に保つ方針）。
  */
-export function resolveImageExportSize(options: ImageExportOptions = {}): ImageExportSize {
+export function resolveImageExportSize(
+  zone: FieldZone,
+  options: ImageExportOptions = {},
+): ImageExportSize {
   const width = resolveImageExportWidth(options.width);
-  return { width, height: Math.round(width / FIELD_WINDOW_ASPECT) };
+  return { width, height: Math.round(width / fieldWindowAspect(zone)) };
 }

--- a/src/common/formations/presets.test.ts
+++ b/src/common/formations/presets.test.ts
@@ -23,7 +23,7 @@ describe("FORMATION_PRESETS データ健全性", () => {
         expect(Number.isFinite(p.position.absoluteYard)).toBe(true);
         // 守は赤で塗り、攻は色なし（テーマ既定）。
         if (formation.side === "defense") {
-          expect(p.color).toBe("#c62828");
+          expect(p.color).toBe("#b23a30");
         } else {
           expect(p.color).toBeUndefined();
         }

--- a/src/common/formations/presets.ts
+++ b/src/common/formations/presets.ts
@@ -5,8 +5,8 @@
 import type { PlayerShape } from "../model/player.js";
 import type { Formation, FormationPlayer } from "./formation.js";
 
-/** ディフェンス選手の既定色（攻守を一目で区別できるよう赤系）。 */
-const DEFENSE_COLOR = "#c62828";
+/** ディフェンス選手の既定色（攻守を一目で区別できるよう、くすませた赤）。 */
+const DEFENSE_COLOR = "#b23a30";
 
 /** オフェンス選手テンプレート（色なし＝テーマ既定）。 */
 function off(
@@ -39,10 +39,10 @@ const OFFENSIVE_LINE: FormationPlayer[] = [
 
 // ディフェンスライン（4 人）は両隊形で共通。
 const DEFENSIVE_LINE: FormationPlayer[] = [
-  def("", 21, 51, "pentagon"),
-  def("", 24.5, 51, "pentagon"),
-  def("", 29, 51, "pentagon"),
-  def("", 32.5, 51, "pentagon"),
+  def("", 21, 51, "circle"),
+  def("", 24.5, 51, "circle"),
+  def("", 29, 51, "circle"),
+  def("", 32.5, 51, "circle"),
 ];
 
 const I_FORMATION: Formation = {
@@ -51,10 +51,10 @@ const I_FORMATION: Formation = {
   side: "offense",
   players: [
     ...OFFENSIVE_LINE,
-    off("TE", 33.6, 49.5, "triangle"),
+    off("TE", 33.6, 49.5, "square"),
     off("QB", 26.7, 47.5, "circle"),
-    off("FB", 26.7, 45, "diamond"),
-    off("RB", 26.7, 42.5, "diamond"),
+    off("FB", 26.7, 45, "circle"),
+    off("RB", 26.7, 42.5, "circle"),
     off("X", 7, 49.5, "circle"),
     off("Z", 46, 49.5, "circle"),
   ],
@@ -67,7 +67,7 @@ const SHOTGUN_SPREAD: Formation = {
   players: [
     ...OFFENSIVE_LINE,
     off("QB", 26.7, 45, "circle"),
-    off("RB", 29.7, 45, "diamond"),
+    off("RB", 29.7, 45, "circle"),
     off("X", 6, 49.5, "circle"),
     off("Y", 13, 49, "circle"),
     off("H", 40, 49, "circle"),
@@ -81,13 +81,13 @@ const DEFENSE_4_3: Formation = {
   side: "defense",
   players: [
     ...DEFENSIVE_LINE,
-    def("S", 20, 54.5, "hexagon"),
-    def("M", 26.7, 54.5, "hexagon"),
-    def("W", 33, 54.5, "hexagon"),
-    def("", 7, 53, "hexagon"),
-    def("", 46, 53, "hexagon"),
-    def("FS", 22, 60, "diamond"),
-    def("SS", 31, 60, "diamond"),
+    def("S", 20, 54.5, "circle"),
+    def("M", 26.7, 54.5, "circle"),
+    def("W", 33, 54.5, "circle"),
+    def("", 7, 53, "circle"),
+    def("", 46, 53, "circle"),
+    def("FS", 22, 60, "circle"),
+    def("SS", 31, 60, "circle"),
   ],
 };
 
@@ -97,13 +97,13 @@ const DEFENSE_NICKEL: Formation = {
   side: "defense",
   players: [
     ...DEFENSIVE_LINE,
-    def("M", 23, 54.5, "hexagon"),
-    def("W", 31, 54.5, "hexagon"),
-    def("N", 14, 55, "hexagon"),
-    def("", 7, 53, "hexagon"),
-    def("", 46, 53, "hexagon"),
-    def("FS", 22, 60, "diamond"),
-    def("SS", 31, 60, "diamond"),
+    def("M", 23, 54.5, "circle"),
+    def("W", 31, 54.5, "circle"),
+    def("N", 14, 55, "circle"),
+    def("", 7, 53, "circle"),
+    def("", 46, 53, "circle"),
+    def("FS", 22, 60, "circle"),
+    def("SS", 31, 60, "circle"),
   ],
 };
 

--- a/src/common/geometry/field.test.ts
+++ b/src/common/geometry/field.test.ts
@@ -9,6 +9,7 @@ import {
   isEndZone,
   yardLinesInWindow,
   ZONE_WINDOW_LENGTH_YARDS,
+  zoneWindowLength,
 } from "./field.js";
 
 describe("ハッシュのリーグ別位置", () => {
@@ -27,23 +28,24 @@ describe("ハッシュのリーグ別位置", () => {
 });
 
 describe("fieldZoneWindow", () => {
-  it("own-redzone は自陣EZ(-10)〜自陣RZ(20)を映す", () => {
-    expect(fieldZoneWindow("own-redzone")).toEqual({ startYard: -10, endYard: 20 });
+  it("own-redzone は自陣EZ(-10)〜自陣25yd(25)を映す", () => {
+    expect(fieldZoneWindow("own-redzone")).toEqual({ startYard: -10, endYard: 25 });
   });
 
-  it("redzone は相手RZ(80)〜相手EZ(110)を映す", () => {
-    expect(fieldZoneWindow("redzone")).toEqual({ startYard: 80, endYard: 110 });
+  it("redzone は相手25yd(75)〜相手EZ(110)を映す", () => {
+    expect(fieldZoneWindow("redzone")).toEqual({ startYard: 75, endYard: 110 });
   });
 
   it("middle はセンター 50 を中央に置く 35..65", () => {
     expect(fieldZoneWindow("middle")).toEqual({ startYard: 35, endYard: 65 });
   });
+});
 
-  it("どのゾーンも窓の長さは 30 ヤード", () => {
-    for (const zone of ["middle", "redzone", "own-redzone"] as const) {
-      const w = fieldZoneWindow(zone);
-      expect(w.endYard - w.startYard).toBe(ZONE_WINDOW_LENGTH_YARDS);
-    }
+describe("zoneWindowLength", () => {
+  it("middle は 30yd、レッドゾーン系は数字の見切れ回避で 35yd", () => {
+    expect(zoneWindowLength("middle")).toBe(ZONE_WINDOW_LENGTH_YARDS);
+    expect(zoneWindowLength("redzone")).toBe(35);
+    expect(zoneWindowLength("own-redzone")).toBe(35);
   });
 });
 
@@ -89,8 +91,8 @@ describe("yardLinesInWindow", () => {
     expect(yardLinesInWindow("own-redzone", 10)).toEqual([-10, 0, 10, 20]);
   });
 
-  it("redzone を 5 ヤード刻みで列挙する（相手 EZ の 110 まで）", () => {
-    expect(yardLinesInWindow("redzone", 5)).toEqual([80, 85, 90, 95, 100, 105, 110]);
+  it("redzone を 5 ヤード刻みで列挙する（相手 25yd の 75 から EZ の 110 まで）", () => {
+    expect(yardLinesInWindow("redzone", 5)).toEqual([75, 80, 85, 90, 95, 100, 105, 110]);
   });
 
   it("刻み幅が 0 以下なら例外", () => {
@@ -138,7 +140,7 @@ describe("FieldGeometry", () => {
     const middle = new FieldGeometry(1000, 600, "middle");
     const redzone = new FieldGeometry(1000, 600, "redzone");
 
-    // 50 は middle 窓の中央だが redzone(80..110) では窓外で下端より下になる。
+    // 50 は middle 窓の中央だが redzone(75..110) では窓外で下端より下になる。
     expect(middle.yForAbsoluteYard(50)).toBeCloseTo(
       middle.offsetY + middle.fieldPixelHeight / 2,
       10,

--- a/src/common/geometry/field.test.ts
+++ b/src/common/geometry/field.test.ts
@@ -1,13 +1,30 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_FIELD_LEAGUE,
   displayYardNumber,
   FIELD_WIDTH_YARDS,
   FieldGeometry,
   fieldZoneWindow,
+  HASH_CENTER_OFFSET_YARDS_BY_LEAGUE,
   isEndZone,
   yardLinesInWindow,
   ZONE_WINDOW_LENGTH_YARDS,
 } from "./field.js";
+
+describe("ハッシュのリーグ別位置", () => {
+  it("既定は NCAA で、サイドラインから 20yd（中央±0.125W）に来る", () => {
+    expect(DEFAULT_FIELD_LEAGUE).toBe("ncaa");
+    const offset = HASH_CENTER_OFFSET_YARDS_BY_LEAGUE.ncaa;
+    expect(offset).toBeCloseTo(FIELD_WIDTH_YARDS * 0.125);
+    expect(FIELD_WIDTH_YARDS / 2 - offset).toBeCloseTo(20);
+  });
+
+  it("NFHS > NCAA > NFL の順で中央オフセットが大きい（ハッシュが広い）", () => {
+    const { ncaa, nfl, nfhs } = HASH_CENTER_OFFSET_YARDS_BY_LEAGUE;
+    expect(nfhs).toBeGreaterThan(ncaa);
+    expect(ncaa).toBeGreaterThan(nfl);
+  });
+});
 
 describe("fieldZoneWindow", () => {
   it("own-redzone は自陣EZ(-10)〜自陣RZ(20)を映す", () => {

--- a/src/common/geometry/field.ts
+++ b/src/common/geometry/field.ts
@@ -18,6 +18,22 @@ export const ZONE_WINDOW_LENGTH_YARDS = 30;
 export const HASH_FROM_SIDELINE_YARDS = 20;
 
 /**
+ * リーグ別ハッシュ位置（中央からの片側オフセット, yd）。レンダラはこの表を引くだけで
+ * 切り替えられるよう定数化する（NCAA は左右間 40ft、NFL は約 18.5ft、NFHS は 53⅓ft）。
+ * 既定は日本で主流の NCAA。runtime 切替の API 化は将来課題（PRD 4.1 で範囲を絞る）。
+ */
+export const HASH_CENTER_OFFSET_YARDS_BY_LEAGUE = {
+  ncaa: FIELD_WIDTH_YARDS * 0.125,
+  nfl: FIELD_WIDTH_YARDS * 0.0578,
+  nfhs: FIELD_WIDTH_YARDS * 0.1667,
+} as const;
+
+export type FieldLeague = keyof typeof HASH_CENTER_OFFSET_YARDS_BY_LEAGUE;
+
+/** 既定リーグ。NCAA のハッシュ間 40ft が日本の標準。 */
+export const DEFAULT_FIELD_LEAGUE: FieldLeague = "ncaa";
+
+/**
  * 「9 ヤードマーク」（short hash）のサイドラインからの距離。
  * 実フィールドでサイドライン際の球位置を素早く判定するための補助目盛。
  */

--- a/src/common/geometry/field.ts
+++ b/src/common/geometry/field.ts
@@ -8,7 +8,11 @@ import type { FieldPosition } from "../model/player.js";
 /** フィールド幅（サイドライン間）= 規定 160 ft = 53.33 yd。 */
 export const FIELD_WIDTH_YARDS = 160 / 3;
 
-/** 1 ゾーンで映す縦方向の長さ（PRD 5.1「約 30 ヤード分」）。 */
+/**
+ * middle ゾーンで映す縦長（PRD 5.1「約 30 ヤード分」）。
+ * レッドゾーン窓は数字の見切れ回避でこれより深い（RED_ZONE_DEPTH + END_ZONE = 35）。
+ * 窓ごとの実長は zoneWindowLength で得る。
+ */
 export const ZONE_WINDOW_LENGTH_YARDS = 30;
 
 /**
@@ -42,13 +46,17 @@ export const NEAR_SIDELINE_TICK_YARDS = 9;
 /** 1 ヤード刻みティックの目盛り長（ヤード）。実フィールドの 1 ヤード刻みを再現。 */
 export const HASH_TICK_YARDS = 0.8;
 
-/** レッドゾーンの奥行き（ゴール前 20 ヤード）。 */
-export const RED_ZONE_DEPTH_YARDS = 20;
+/**
+ * レッドゾーン窓に映す奥行き（25 ヤードライン〜ゴール）。実レッドゾーン（ゴール前 20yd）
+ * より広いのは、20yd ラインが窓端に乗って数字が見切れるのを避けるため。
+ */
+export const RED_ZONE_DEPTH_YARDS = 25;
 
 /**
  * エンドゾーンの奥行き（ゴールラインの外側 10 ヤード）。
  * これにより絶対ヤードの定義域は -10..110（自陣 EZ 〜 相手陣 EZ）に広がる。
- * RED_ZONE_DEPTH_YARDS(20) + END_ZONE_DEPTH_YARDS(10) = ZONE_WINDOW_LENGTH_YARDS(30)。
+ * RED_ZONE_DEPTH_YARDS(25) + END_ZONE_DEPTH_YARDS(10) = レッドゾーン窓 35yd
+ * （中央窓 ZONE_WINDOW_LENGTH_YARDS=30 より深い）。
  */
 export const END_ZONE_DEPTH_YARDS = 10;
 
@@ -60,18 +68,18 @@ export interface YardWindow {
 }
 
 /**
- * ゾーン → 表示する絶対ヤード窓 [start, end]（常に長さ 30）。
+ * ゾーン → 表示する絶対ヤード窓 [start, end]。middle は 30yd、レッドゾーン系は 35yd。
  * 絶対ヤードは -10 = 自陣エンドライン / 0 = 自ゴール / 50 = センター /
  * 100 = 相手ゴール / 110 = 相手エンドライン。攻撃方向は増加方向（= 画面上）。
- * レッドゾーン系は実スコアリング領域（ゴール前 20yd）＋エンドゾーン 10yd を映す。
+ * レッドゾーン系は 25 ヤードライン〜ゴール＋エンドゾーン 10yd を映す。
  */
 export function fieldZoneWindow(zone: FieldZone): YardWindow {
   switch (zone) {
     case "own-redzone":
-      // 自陣エンドゾーン(-10..0) + 自陣レッドゾーン(0..20)。
+      // 自陣エンドゾーン(-10..0) + 自陣 25yd まで(0..25)。
       return { startYard: -END_ZONE_DEPTH_YARDS, endYard: RED_ZONE_DEPTH_YARDS };
     case "redzone":
-      // 相手レッドゾーン(80..100) + 相手エンドゾーン(100..110)。
+      // 相手 25yd まで(75..100) + 相手エンドゾーン(100..110)。
       return { startYard: 100 - RED_ZONE_DEPTH_YARDS, endYard: 100 + END_ZONE_DEPTH_YARDS };
     case "middle": {
       // センター(50)を窓の中央に置く。
@@ -79,6 +87,12 @@ export function fieldZoneWindow(zone: FieldZone): YardWindow {
       return { startYard: 50 - half, endYard: 50 + half };
     }
   }
+}
+
+/** ゾーン窓の縦長（yd）。middle は 30、レッドゾーン系は 35。geometry / export 共用。 */
+export function zoneWindowLength(zone: FieldZone): number {
+  const { startYard, endYard } = fieldZoneWindow(zone);
+  return endYard - startYard;
 }
 
 /** フィールド外（エンドゾーン）か。境界のゴールライン 0/100 は含めない。 */
@@ -142,11 +156,12 @@ export class FieldGeometry {
     readonly zone: FieldZone,
   ) {
     this.window = fieldZoneWindow(zone);
+    const windowLength = this.window.endYard - this.window.startYard;
     const w = Math.max(0, viewportWidth);
     const h = Math.max(0, viewportHeight);
-    this.scale = Math.min(w / FIELD_WIDTH_YARDS, h / ZONE_WINDOW_LENGTH_YARDS);
+    this.scale = Math.min(w / FIELD_WIDTH_YARDS, h / windowLength);
     this.fieldPixelWidth = FIELD_WIDTH_YARDS * this.scale;
-    this.fieldPixelHeight = ZONE_WINDOW_LENGTH_YARDS * this.scale;
+    this.fieldPixelHeight = windowLength * this.scale;
     this.offsetX = (w - this.fieldPixelWidth) / 2;
     this.offsetY = (h - this.fieldPixelHeight) / 2;
   }

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -22,6 +22,7 @@ export {
   RemovePlayerCommand,
   UpdatePlayerCommand,
 } from "./commands/player-commands.js";
+export { computeFieldMetrics, type FieldMetrics } from "./design/metrics.js";
 export {
   EditorController,
   type EditorOverlay,
@@ -57,11 +58,14 @@ export {
 } from "./geometry/bezier.js";
 export {
   type CanvasPoint,
+  DEFAULT_FIELD_LEAGUE,
   displayYardNumber,
   END_ZONE_DEPTH_YARDS,
   FIELD_WIDTH_YARDS,
   FieldGeometry,
+  type FieldLeague,
   fieldZoneWindow,
+  HASH_CENTER_OFFSET_YARDS_BY_LEAGUE,
   HASH_FROM_SIDELINE_YARDS,
   HASH_TICK_YARDS,
   isEndZone,

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -36,7 +36,7 @@ export { IdFactory, type IIdFactory } from "./editing/id-factory.js";
 export { Emitter, type Event } from "./event/emitter.js";
 export {
   DEFAULT_EXPORT_WIDTH,
-  FIELD_WINDOW_ASPECT,
+  fieldWindowAspect,
   type ImageExportOptions,
   type ImageExportSize,
   resolveImageExportSize,
@@ -74,6 +74,7 @@ export {
   type YardWindow,
   yardLinesInWindow,
   ZONE_WINDOW_LENGTH_YARDS,
+  zoneWindowLength,
 } from "./geometry/field.js";
 export {
   distanceToSegment,

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,15 +5,27 @@
  */
 .playmaker-root {
   --playmaker-font-family: system-ui, sans-serif;
-  --playmaker-field-bg: #2e7d32;
-  --playmaker-field-line-color: rgba(255, 255, 255, 0.85);
-  --playmaker-field-number-color: rgba(255, 255, 255, 0.9);
-  --playmaker-player-fill: #1565c0;
-  --playmaker-player-stroke: rgba(255, 255, 255, 0.9);
+  /* ヤード数字はアスレチック系（縦長・極太）を狙う。同梱せず、商用ソフトが
+     @font-face を足せばコンデンス体になる。既定は OS のコンデンス体スタック。 */
+  --playmaker-number-font-family:
+    "Oswald", "Saira Condensed", "Arial Narrow", "Roboto Condensed", sans-serif-condensed,
+    sans-serif;
+  /* フィールドは脇役。彩度・明度を少し落とし、白は純白を避けてプレーを前に出す。 */
+  --playmaker-field-bg: #3f7a46;
+  --playmaker-field-stripe: #3a7341;
+  --playmaker-field-oob: #284b2f;
+  --playmaker-endzone-bg: #20503c;
+  --playmaker-field-line-color: rgba(238, 242, 236, 0.9);
+  --playmaker-field-number-color: rgba(238, 242, 236, 0.9);
+  --playmaker-goal-line-color: #ffffff;
+  --playmaker-pylon-color: #e8722c;
+  --playmaker-goalpost-color: #f3c33a;
+  --playmaker-player-fill: #1e3fae;
+  --playmaker-player-stroke: #eef2ec;
   --playmaker-player-label-color: #ffffff;
-  --playmaker-line-route-color: #ffeb3b;
-  --playmaker-line-block-color: #ffffff;
-  --playmaker-line-motion-color: #ffeb3b;
+  --playmaker-line-route-color: #f3c33a;
+  --playmaker-line-block-color: #eef2ec;
+  --playmaker-line-motion-color: #f3c33a;
   --playmaker-selection-color: #ff9800;
   --playmaker-surface-bg: #ffffff;
   --playmaker-border-color: #d0d0d0;


### PR DESCRIPTION
### Summary

フィールド描画とプレー作図を NCAA 仕様にプロフェッショナル化する。<br>
マーキング層は実寸比率に忠実、注釈層（選手トークン・プレー線）は視認性優先という分離を設計の核に据える。

### Checklist

- [x] Code builds and unit tests pass locally
- [ ] Relevant documentation updated
- [x] Reviewer has sufficient context

### Motivation and Context

ロードマップで MVP スコープ外として明示ドロップしていた「見た目磨き（M9 相当）」の再開。<br>
従来の描画は機能的だが素人っぽく、実物のフィールドに準拠したマーキングと、コーチング図／テレストレーター標準の記法へ刷新する。

### Implementation Details

寸法は固定 px を散らさず `computeFieldMetrics`（`src/common/design/metrics.ts`、純計算・テスト済み）でフィールド幅 W から導く。色は `--playmaker-*` CSS 変数に集約する。<br>
フィールド: 刈り込みストライプ・沈めた白・太いゴールライン・NCAA ハッシュ（中央 ±0.125W、リーグ定数表で切替可）・アスレチック数字（CSS 変数フォント・上下ミラー・方向矢印）・エンドゾーン塗り＋パイロン＋ゴールポスト（内部に線を引かず `0` も描かない）。<br>
トークン: 丸=スキル／四角=ライン の 2 形状・白フチ＋ごく弱い影。<br>
プレー線: route/motion は矢印、block は T 字キャップで記法区別。

### Testing Instructions

1. `pnpm test`（261 件・`src/common` 100% カバレッジゲート込み）。
2. `pnpm dev` で playground を開き、ゾーンを「中央 / 相手RZ / 自陣RZ」で切り替える。
3. 中央: ストライプ・広い NCAA ハッシュ・ミラー数字＋方向矢印・2 形状トークン・route 矢印 / block T 字 / motion 破線を目視。
4. 相手RZ・自陣RZ: エンドゾーン塗り・四隅パイロン・ゴールポスト・太いゴールライン・数字が `10` 止まりで `0` を描かないことを目視。

### Related Issues

なし（仕様は issue 本文として共有済み）。

### Notes for Release

レビュー時の意図的な判断:<br>
- `Player` に `side`/`team` を追加せず、攻=テーマ既定・守=選手 color の既存契約を踏襲（モデルに side を持ち込まない既決方針を尊重）。<br>
- `PlayerShape` の型は 6 種のまま（保存データの後方互換）。2 形状語彙はプリセット・プロパティパネルで実現し、スキーマ版は上げない。<br>
- リーグはコード定数（既定 NCAA）。runtime 切替の API 化は範囲を絞り将来課題。<br>
- 選手マーカーは描画＝hit-test 不変条件を保つためヤード基準を維持（issue の clamp(20,30) は当窓では ≈1.1yd 相当）。<br>
- パス（点線）は新 `LineKind`（モデル変更）が必要なため今回は見送り（issue でも任意）。
