### PR TITLE
feat: プレー図の見た目をプレーブック調へ引き締める

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -39,7 +39,7 @@ const jsonArea: HTMLTextAreaElement = jsonEl;
 const dataStatus: HTMLElement = dataStatusEl;
 
 // 目視用サンプル: 2 形状（丸/四角）・色・ラベル・3 線種・直線/ベジェ・waypoint。
-const DEFENSE_COLOR = "#b23a30";
+const DEFENSE_COLOR = "#8f4034";
 const SAMPLE_PLAYERS: Player[] = [
   { id: "ol-c", position: { lateralYard: 26.7, absoluteYard: 49 }, shape: "square", label: "C" },
   { id: "ol-lg", position: { lateralYard: 24.4, absoluteYard: 49 }, shape: "square", label: "LG" },

--- a/src/browser/rendering/canvas-surface.ts
+++ b/src/browser/rendering/canvas-surface.ts
@@ -168,7 +168,7 @@ export class CanvasSurface extends Disposable {
     const metrics = computeFieldMetrics(geometry.fieldPixelWidth, geometry.scale);
     this.fieldRenderer.draw(ctx, geometry, field, metrics);
     this.lineRenderer.draw(ctx, geometry, data.lines, data.players, line, metrics);
-    this.playerRenderer.draw(ctx, geometry, data.players, player);
+    this.playerRenderer.draw(ctx, geometry, data.players, player, metrics);
   }
 
   /**
@@ -218,13 +218,18 @@ export class CanvasSurface extends Disposable {
       }
     }
 
-    const handleSize = WAYPOINT_HANDLE_RADIUS_YARDS * this.geometry.scale;
+    // アイコンは hit 許容（WAYPOINT_HANDLE_RADIUS_YARDS）の一部だけを描く。フルに
+    // 描くとマーカー並みに大きいので小さく出し、掴みやすさは hit 許容側に委ねる。
+    const handleHalf = Math.max(3, 0.45 * WAYPOINT_HANDLE_RADIUS_YARDS * this.geometry.scale);
     for (const wp of waypointHandles) {
       const { x, y } = this.geometry.toCanvas(wp.lateralYard, wp.absoluteYard);
       this.ctx.beginPath();
-      this.ctx.rect(x - handleSize, y - handleSize, handleSize * 2, handleSize * 2);
+      this.ctx.rect(x - handleHalf, y - handleHalf, handleHalf * 2, handleHalf * 2);
       this.ctx.fillStyle = accent;
       this.ctx.fill();
+      this.ctx.lineWidth = 1.5;
+      this.ctx.strokeStyle = "rgba(255, 255, 255, 0.9)";
+      this.ctx.stroke();
     }
   }
 
@@ -243,19 +248,19 @@ export class CanvasSurface extends Disposable {
         stripeColor: read("--playmaker-field-stripe", "#3a7341"),
         oobColor: read("--playmaker-field-oob", "#284b2f"),
         endzoneColor: read("--playmaker-endzone-bg", "#20503c"),
-        lineColor: read("--playmaker-field-line-color", "rgba(238, 242, 236, 0.9)"),
-        goalLineColor: read("--playmaker-goal-line-color", "#ffffff"),
-        numberColor: read("--playmaker-field-number-color", "rgba(238, 242, 236, 0.9)"),
-        pylonColor: read("--playmaker-pylon-color", "#e8722c"),
-        goalpostColor: read("--playmaker-goalpost-color", "#f3c33a"),
+        lineColor: read("--playmaker-field-line-color", "rgba(236, 240, 234, 0.82)"),
+        goalLineColor: read("--playmaker-goal-line-color", "rgba(255, 255, 255, 0.92)"),
+        numberColor: read("--playmaker-field-number-color", "rgba(236, 240, 234, 0.72)"),
+        pylonColor: read("--playmaker-pylon-color", "#d06a30"),
+        goalpostColor: read("--playmaker-goalpost-color", "#c2a64a"),
       },
       line: {
-        routeColor: read("--playmaker-line-route-color", "#f3c33a"),
-        blockColor: read("--playmaker-line-block-color", "#eef2ec"),
-        motionColor: read("--playmaker-line-motion-color", "#f3c33a"),
+        routeColor: read("--playmaker-line-route-color", "#c49a3c"),
+        blockColor: read("--playmaker-line-block-color", "#c49a3c"),
+        motionColor: read("--playmaker-line-motion-color", "#c49a3c"),
       },
       player: {
-        fillColor: read("--playmaker-player-fill", "#1e3fae"),
+        fillColor: read("--playmaker-player-fill", "#2b4c72"),
         strokeColor: read("--playmaker-player-stroke", "#eef2ec"),
         labelColor: read("--playmaker-player-label-color", "#ffffff"),
       },

--- a/src/browser/rendering/line-renderer.ts
+++ b/src/browser/rendering/line-renderer.ts
@@ -58,6 +58,7 @@ export class LineRenderer {
 
       const color = line.color ?? this.colorFor(line.kind, theme);
       const width = line.thickness ?? this.widthFor(line.kind, metrics);
+      const isBlock = line.kind === "block";
 
       ctx.save();
       ctx.strokeStyle = color;
@@ -68,18 +69,21 @@ export class LineRenderer {
         ctx.setLineDash([...metrics.motionDash]);
       }
 
+      // 矢印付きの線は根元で止める＝線が矢じり内へ潜らず先端が鋭く整う。ブロックは
+      // 終端に T 字キャップを当てるため終点まで引く。矢じりの向き/位置は元 path から得る。
+      const strokePath = isBlock ? path : this.trimForArrow(path, metrics.arrowLength);
       ctx.beginPath();
-      const head = path[0] as CanvasPoint;
+      const head = strokePath[0] as CanvasPoint;
       ctx.moveTo(head.x, head.y);
-      for (let i = 1; i < path.length; i++) {
-        const pt = path[i] as CanvasPoint;
+      for (let i = 1; i < strokePath.length; i++) {
+        const pt = strokePath[i] as CanvasPoint;
         ctx.lineTo(pt.x, pt.y);
       }
       ctx.stroke();
       ctx.setLineDash([]);
 
       // 記法で区別: 走路は矢印、ブロックは T 字キャップ。
-      if (line.kind === "block") {
+      if (isBlock) {
         this.drawBlockCap(ctx, path, color, metrics, width);
       } else {
         this.drawArrowHead(ctx, path, color, metrics);
@@ -117,6 +121,27 @@ export class LineRenderer {
       }
     }
     return undefined;
+  }
+
+  /**
+   * 矢じりの根元（終点から arrowLength 手前）で終わるポリラインを返す。
+   * 線が三角の内側に潜って先端が潰れるのを防ぐ。最終区間が矢じりより短い場合は
+   * 線が消えないよう区間の 90% までに留める（残りは矢じりが覆う）。
+   */
+  private trimForArrow(path: readonly CanvasPoint[], arrowLength: number): readonly CanvasPoint[] {
+    if (path.length < 2) {
+      return path;
+    }
+    const angle = this.endAngle(path);
+    if (angle === undefined) {
+      return path;
+    }
+    const tip = path[path.length - 1] as CanvasPoint;
+    const prev = path[path.length - 2] as CanvasPoint;
+    const segLen = Math.hypot(tip.x - prev.x, tip.y - prev.y);
+    const pull = Math.min(arrowLength, segLen * 0.9);
+    const neck = { x: tip.x - pull * Math.cos(angle), y: tip.y - pull * Math.sin(angle) };
+    return [...path.slice(0, -1), neck];
   }
 
   /** 終点に、進行方向へ向けた塗り三角の矢じりを描く（route / motion）。 */

--- a/src/browser/rendering/player-renderer.ts
+++ b/src/browser/rendering/player-renderer.ts
@@ -5,6 +5,7 @@
 import {
   FIELD_FONT_FAMILY,
   type FieldGeometry,
+  type FieldMetrics,
   PLAYER_RADIUS_YARDS,
   type Player,
   type PlayerShape,
@@ -19,8 +20,6 @@ export interface PlayerTheme {
   /** ラベル文字色。 */
   labelColor: string;
 }
-
-const STROKE_WIDTH = 2;
 
 // 正多角形の頂点角（apex を上に向ける）。circle は arc で特別扱い。
 // 当たり領域（hit-test）は半径 r の外接円なので、全頂点を r 上に置き整合させる。
@@ -51,49 +50,43 @@ export class PlayerRenderer {
     geometry: FieldGeometry,
     players: readonly Player[],
     theme: PlayerTheme,
+    metrics: FieldMetrics,
   ): void {
+    // 半径は hit-test と一致させるため PLAYER_RADIUS_YARDS から導く（player.ts の不変条件）。
+    // 枠線・ラベルは D 比トークン（metrics）を使い、寸法を 1 か所へ集約する。
     const r = PLAYER_RADIUS_YARDS * geometry.scale;
     if (r <= 0) {
       return;
     }
-    // ラベルは選手マーカーの中に収まるサイズに抑える（半径の 1/3 ほど）。
-    const fontPx = Math.max(8, r * 0.35);
-    // 芝から浮かせる白フチ + ごく弱い影。影を強くするとダサくなるので控えめに。
-    const shadowBlur = Math.max(2, r * 0.18);
-    const shadowOffset = Math.max(1, r * 0.08);
+    const fontPx = metrics.markerLabelFont;
+    const strokeWidth = metrics.markerStroke;
 
     for (const player of players) {
       const { x, y } = geometry.toCanvas(player.position.lateralYard, player.position.absoluteYard);
 
-      ctx.save();
+      // 影・グラデーションを持たない完全フラット。塗り → 枠線の順で描く。
       ctx.beginPath();
       if (player.shape === "circle") {
         ctx.arc(x, y, r, 0, Math.PI * 2);
       } else {
         this.tracePolygon(ctx, x, y, r, player.shape);
       }
-
-      // 影は塗りにだけ載せる（フチ/ラベルへ二重に乗らないよう塗り直後に解除）。
-      ctx.shadowColor = "rgba(0, 0, 0, 0.4)";
-      ctx.shadowBlur = shadowBlur;
-      ctx.shadowOffsetY = shadowOffset;
       ctx.fillStyle = player.color ?? theme.fillColor;
       ctx.fill();
-      ctx.shadowColor = "transparent";
-      ctx.shadowBlur = 0;
-      ctx.shadowOffsetY = 0;
-
-      ctx.lineWidth = STROKE_WIDTH;
+      ctx.lineWidth = strokeWidth;
       ctx.strokeStyle = theme.strokeColor;
       ctx.stroke();
-      ctx.restore();
 
       if (player.label !== "") {
         ctx.fillStyle = theme.labelColor;
         ctx.font = `700 ${fontPx}px ${FIELD_FONT_FAMILY}`;
         ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillText(player.label, x, y);
+        // textBaseline="middle" は em ボックス基準でフォント次第で上下にずれる。
+        // 実際の字面ボックス（actualBoundingBox）の中心をマーカー中心へ合わせる。
+        ctx.textBaseline = "alphabetic";
+        const tm = ctx.measureText(player.label);
+        const labelY = y + (tm.actualBoundingBoxAscent - tm.actualBoundingBoxDescent) / 2;
+        ctx.fillText(player.label, x, labelY);
       }
     }
   }

--- a/src/common/design/metrics.test.ts
+++ b/src/common/design/metrics.test.ts
@@ -14,11 +14,13 @@ describe("computeFieldMetrics", () => {
     expect(m.hashTickLength).toBeCloseTo(0.375 * U);
     expect(m.numberHeight).toBeCloseTo(2.4 * U);
     expect(m.tokenDiameter).toBeCloseTo(D);
+    expect(m.markerStroke).toBeCloseTo(D / 14);
+    expect(m.markerLabelFont).toBeCloseTo(0.5 * D);
     expect(m.routeWidth).toBeCloseTo(0.11 * D);
     expect(m.blockWidth).toBeCloseTo(m.routeWidth);
     expect(m.blockCapLength).toBeCloseTo(0.4 * D);
-    expect(m.arrowLength).toBeCloseTo(D);
-    expect(m.arrowHalfWidth).toBeCloseTo(0.62 * D);
+    expect(m.arrowLength).toBeCloseTo(0.72 * D);
+    expect(m.arrowHalfWidth).toBeCloseTo(0.24 * D);
     expect(m.motionDash[0]).toBeCloseTo(1.1 * U);
     expect(m.motionDash[1]).toBeCloseTo(0.7 * U);
   });
@@ -43,6 +45,8 @@ describe("computeFieldMetrics", () => {
     expect(m.hashTickLength).toBe(0);
     expect(m.numberHeight).toBe(10);
     expect(m.tokenDiameter).toBe(0);
+    expect(m.markerStroke).toBe(1);
+    expect(m.markerLabelFont).toBe(8);
     expect(m.routeWidth).toBe(1.5);
     expect(m.arrowLength).toBe(0);
     expect(m.motionDash).toEqual([0, 0]);

--- a/src/common/design/metrics.ts
+++ b/src/common/design/metrics.ts
@@ -19,11 +19,18 @@ const NUMBER_HEIGHT_PER_U = 2.4; // 実寸 6ft(=2yd) を視認用に拡大（2.3
 const NUMBER_MIN_PX = 10;
 
 // 注釈層（D 基準・視認性優先）。
+const MARKER_STROKE_PER_D = 1 / 14; // D/16〜D/12 の範囲。芝に対し細すぎず太すぎず。
+const MARKER_STROKE_MIN_PX = 1;
+const MARKER_LABEL_PER_D = 0.5; // D×0.45〜0.55。マーカー内にちょうど収まる字面。
+const MARKER_LABEL_MIN_PX = 8;
 const ROUTE_WIDTH_PER_D = 0.11;
 const ROUTE_WIDTH_MIN_PX = 1.5;
 const BLOCK_CAP_LENGTH_PER_D = 0.4; // T 字キャップ長。ルート矢印と一目で見分く大きさ。
-const ARROW_LENGTH_PER_D = 1.0;
-const ARROW_HALF_WIDTH_PER_D = 0.62;
+// 矢じりは鋭く整った塗り三角。底辺幅(2·halfWidth ≈ 0.48D)を線幅(0.11D)より十分広く取り
+// 「棘」に見せない。全角 ≈ 37°（halfWidth / length = tan(18.4°)）で鋭さと視認性を両立。
+// 描画側は矢じり根元で線を止め、線が三角内へ潜って先端が潰れるのを防ぐ。
+const ARROW_LENGTH_PER_D = 0.72;
+const ARROW_HALF_WIDTH_PER_D = 0.24;
 const MOTION_DASH_ON_PER_U = 1.1;
 const MOTION_DASH_OFF_PER_U = 0.7;
 
@@ -37,6 +44,10 @@ export interface FieldMetrics {
   numberHeight: number;
   /** 注釈層の基準直径 D（実マーカー直径）。 */
   tokenDiameter: number;
+  /** 選手マーカーの枠線幅（D 比）。固定 px を散らさず表示サイズに追従する。 */
+  markerStroke: number;
+  /** 選手ラベルのフォント px（D 比）。マーカー内に収まる。 */
+  markerLabelFont: number;
   routeWidth: number;
   /** block も route と同じ太さ。記法（T 字）で区別する。 */
   blockWidth: number;
@@ -63,6 +74,8 @@ export function computeFieldMetrics(fieldPixelWidth: number, unitPx: number): Fi
     hashTickLength: HASH_TICK_LENGTH_PER_U * u,
     numberHeight: Math.max(NUMBER_MIN_PX, NUMBER_HEIGHT_PER_U * u),
     tokenDiameter: d,
+    markerStroke: Math.max(MARKER_STROKE_MIN_PX, MARKER_STROKE_PER_D * d),
+    markerLabelFont: Math.max(MARKER_LABEL_MIN_PX, MARKER_LABEL_PER_D * d),
     routeWidth,
     blockWidth: routeWidth,
     blockCapLength: BLOCK_CAP_LENGTH_PER_D * d,

--- a/src/common/formations/presets.test.ts
+++ b/src/common/formations/presets.test.ts
@@ -23,7 +23,7 @@ describe("FORMATION_PRESETS データ健全性", () => {
         expect(Number.isFinite(p.position.absoluteYard)).toBe(true);
         // 守は赤で塗り、攻は色なし（テーマ既定）。
         if (formation.side === "defense") {
-          expect(p.color).toBe("#b23a30");
+          expect(p.color).toBe("#8f4034");
         } else {
           expect(p.color).toBeUndefined();
         }

--- a/src/common/formations/presets.ts
+++ b/src/common/formations/presets.ts
@@ -6,7 +6,7 @@ import type { PlayerShape } from "../model/player.js";
 import type { Formation, FormationPlayer } from "./formation.js";
 
 /** ディフェンス選手の既定色（攻守を一目で区別できるよう、くすませた赤）。 */
-const DEFENSE_COLOR = "#b23a30";
+const DEFENSE_COLOR = "#8f4034";
 
 /** オフェンス選手テンプレート（色なし＝テーマ既定）。 */
 function off(

--- a/src/common/model/player.ts
+++ b/src/common/model/player.ts
@@ -25,7 +25,7 @@ const PLAYER_SHAPES: readonly PlayerShape[] = [
  * 必ず一致するよう common に置き両層で共有する。フィールドは縦横等倍スケールのため、
  * ヤード空間の円形当たり判定がそのまま画面上の円になる。
  */
-export const PLAYER_RADIUS_YARDS = 1.1;
+export const PLAYER_RADIUS_YARDS = 0.93;
 
 /**
  * フィールド上の論理位置（ヤード空間）。geometry の語彙に揃える。

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,17 +26,19 @@
   --playmaker-field-stripe: #3a7341;
   --playmaker-field-oob: #284b2f;
   --playmaker-endzone-bg: #20503c;
-  --playmaker-field-line-color: rgba(238, 242, 236, 0.9);
-  --playmaker-field-number-color: rgba(238, 242, 236, 0.9);
-  --playmaker-goal-line-color: #ffffff;
-  --playmaker-pylon-color: #e8722c;
-  --playmaker-goalpost-color: #f3c33a;
-  --playmaker-player-fill: #1e3fae;
+  --playmaker-field-line-color: rgba(236, 240, 234, 0.82);
+  --playmaker-field-number-color: rgba(236, 240, 234, 0.72);
+  --playmaker-goal-line-color: rgba(255, 255, 255, 0.92);
+  --playmaker-pylon-color: #d06a30;
+  --playmaker-goalpost-color: #c2a64a;
+  /* オフェンスは沈めたスレート、ディフェンスはくすませた煉瓦（presets 側）。原色フル彩度を避ける。 */
+  --playmaker-player-fill: #2b4c72;
   --playmaker-player-stroke: #eef2ec;
   --playmaker-player-label-color: #ffffff;
-  --playmaker-line-route-color: #f3c33a;
-  --playmaker-line-block-color: #eef2ec;
-  --playmaker-line-motion-color: #f3c33a;
+  /* オフェンス動線は 1 色（落ち着いた琥珀）。route/block/motion は記法（矢印/T 字/破線）で区別する。 */
+  --playmaker-line-route-color: #c49a3c;
+  --playmaker-line-block-color: #c49a3c;
+  --playmaker-line-motion-color: #c49a3c;
   --playmaker-selection-color: #ff9800;
   --playmaker-surface-bg: #ffffff;
   --playmaker-border-color: #d0d0d0;


### PR DESCRIPTION
### Summary

プレー図の見た目を「子供向けのお絵描き」風からプロのプレーブック調へ引き締める。<br>
機能は変えず、サイズ・配色・線・矢じり・ハンドルの見た目のみを調整する。

### Checklist

- [x] Code builds and unit tests pass locally
- [ ] Relevant documentation updated
- [x] Reviewer has sufficient context

### Motivation and Context

選手マーカーが大きく不揃い、矢じりが鈍く太い、原色フル彩度の青・赤・金を多用、の 3 点が「ダサさ」の主因だった。<br>
寸法・配色を引き締め、プレーを主役・フィールドを脇役にする。

### Implementation Details

マーカー直径をフィールド幅の 3.5% 以下へ縮め、影・グラデーションを除いてフラット化し、枠線・ラベルを D 比トークン（`metrics.ts`）へ集約する。<br>
矢じりは鈍い大三角から鋭い細身三角へ変え、根元で線を止めて先端の潰れを防ぐ。<br>
配色は選手スレート・ディフェンス煉瓦・オフェンス動線を琥珀 1 色（種別は矢印 / T 字 / 破線の記法で区別）へ低彩度化する。<br>
ウェイポイントのアイコンは当たり許容（`WAYPOINT_HANDLE_RADIUS_YARDS`）と分離して小さく描き、掴みやすさは hit 許容側で担保する。<br>
ラベルは `measureText` の実字面ボックス中心でマーカー中心へ揃える。

### Testing Instructions

`pnpm run test` で寸法トークン・プリセット色の単体テストが通ることを確認する。<br>
`pnpm run dev` の playground でマーカー・矢じり・線・ライン選択時のハンドルを目視する。

### Related Issues

特になし。

### Notes for Release

`--playmaker-*` の既定配色とマーカー寸法が変わる。商用ソフト側で CSS 変数を上書きしていれば従来どおり追従する。
