### PR TITLE
feat: プレー図/フォーメーションのプリセット拡充とデモのレイアウト刷新

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,92 +4,357 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Playmaker Playground</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Saira+Condensed:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <style>
+      :root {
+        --bg: #161e27;
+        --surface: #1f2a36;
+        --surface-2: #283643;
+        --border: #36465a;
+        --ink: #e7ecf1;
+        --ink-dim: #97a6b6;
+        --accent: #f2c14e;
+        --accent-ink: #161e27;
+        --cat-run: #e0894a;
+        --cat-pass: #5aa1d8;
+        --cat-rpo: #c483cf;
+        --cat-cov: #5fb59c;
+        --cat-pres: #e06457;
+        --off: #f2c14e;
+        --def: #d08573;
+        --display: "Saira Condensed", "Arial Narrow", "Roboto Condensed", system-ui, sans-serif;
+        --ui: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Noto Sans JP",
+          system-ui, sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
       html,
       body {
         margin: 0;
         height: 100%;
-        font-family: system-ui, sans-serif;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: var(--ui);
       }
+
       #app {
         display: flex;
         flex-direction: column;
         height: 100vh;
       }
-      header {
+
+      /* ---- トップバー ---- */
+      .topbar {
         display: flex;
         align-items: center;
-        gap: 16px;
-        padding: 8px 12px;
-        border-bottom: 1px solid #ddd;
-        font-size: 14px;
+        gap: 18px;
+        padding: 10px 18px;
+        background: linear-gradient(180deg, #1d2733, #161e27);
+        border-bottom: 1px solid var(--border);
       }
-      #controls {
+      .brand {
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+        min-width: 0;
+      }
+      .brand__name {
+        font-family: var(--display);
+        font-weight: 700;
+        font-size: 24px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--ink);
+      }
+      .brand__tag {
+        font-size: 12px;
+        color: var(--ink-dim);
+        letter-spacing: 0.02em;
+        white-space: nowrap;
+      }
+      .topbar__spacer {
+        flex: 1;
+      }
+      .topbar__actions {
+        display: flex;
+        gap: 8px;
+      }
+
+      .btn {
+        font: inherit;
+        font-size: 13px;
+        padding: 7px 13px;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        background: var(--surface-2);
+        color: var(--ink);
+        cursor: pointer;
+        transition: border-color 0.12s, background 0.12s;
+      }
+      .btn:hover {
+        border-color: var(--accent);
+      }
+      .btn[aria-pressed="true"] {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--accent-ink);
+        font-weight: 600;
+      }
+
+      /* ---- 本体（左レール＋ステージ） ---- */
+      .body {
+        display: flex;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .library {
+        width: 300px;
+        flex-shrink: 0;
+        display: flex;
+        flex-direction: column;
+        background: var(--surface);
+        border-right: 1px solid var(--border);
+      }
+      .library__scroll {
+        flex: 1;
+        overflow-y: auto;
+        padding: 6px 0 14px;
+      }
+      .group__title {
+        font-family: var(--display);
+        font-weight: 600;
+        font-size: 13px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--ink-dim);
+        padding: 16px 16px 6px;
+      }
+      .group__sub {
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--def);
+        padding: 8px 16px 4px;
+      }
+      .group__sub--off {
+        color: var(--off);
+      }
+
+      .preset {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        width: 100%;
+        text-align: left;
+        font: inherit;
+        padding: 7px 16px;
+        border: 0;
+        border-left: 3px solid transparent;
+        background: transparent;
+        color: var(--ink);
+        cursor: pointer;
+      }
+      .preset:hover {
+        background: var(--surface-2);
+      }
+      .preset.is-active {
+        background: var(--surface-2);
+        border-left-color: var(--accent);
+      }
+      .preset__tag {
+        flex-shrink: 0;
+        width: 38px;
+        font-family: var(--display);
+        font-weight: 700;
+        font-size: 10px;
+        letter-spacing: 0.06em;
+        text-align: center;
+        padding: 2px 0;
+        border-radius: 3px;
+        color: var(--accent-ink);
+      }
+      .preset__name {
+        font-family: var(--display);
+        font-weight: 500;
+        font-size: 15px;
+        letter-spacing: 0.01em;
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      /* ---- Play info カード ---- */
+      .playinfo {
+        border-top: 1px solid var(--border);
+        background: var(--bg);
+        padding: 12px 16px 14px;
+      }
+      .playinfo__eyebrow {
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--ink-dim);
+      }
+      .playinfo__name {
+        font-family: var(--display);
+        font-weight: 700;
+        font-size: 22px;
+        margin: 2px 0 6px;
+        color: var(--ink);
+      }
+      .playinfo__meta {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        margin-bottom: 8px;
+      }
+      .playinfo__chip {
+        font-family: var(--display);
+        font-weight: 700;
+        font-size: 10px;
+        letter-spacing: 0.08em;
+        padding: 2px 7px;
+        border-radius: 3px;
+        color: var(--accent-ink);
+      }
+      .playinfo__pers {
+        font-size: 12px;
+        color: var(--ink-dim);
+      }
+      .playinfo__summary {
+        font-size: 12.5px;
+        line-height: 1.55;
+        color: var(--ink);
+        margin: 0;
+      }
+
+      /* ---- ステージ（フィールド） ---- */
+      .stage-wrap {
+        position: relative;
+        flex: 1;
+        min-width: 0;
+      }
+      #stage {
+        position: absolute;
+        inset: 0;
+      }
+
+      /* ---- 開発者ドロワー ---- */
+      .drawer {
+        background: var(--surface);
+        border-top: 1px solid var(--border);
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.18s ease;
+      }
+      .drawer.is-open {
+        max-height: 46vh;
+        overflow-y: auto;
+      }
+      .drawer__inner {
+        padding: 12px 18px 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .drawer__row {
         display: flex;
         flex-wrap: wrap;
         gap: 6px;
-      }
-      #controls button {
-        padding: 4px 10px;
-        font: inherit;
-        cursor: pointer;
-      }
-      #controls button[aria-pressed="true"] {
-        background: #1565c0;
-        color: #fff;
-        border-color: #1565c0;
-      }
-      #data {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        padding: 6px 12px;
-        border-bottom: 1px solid #ddd;
-      }
-      #data .row {
-        display: flex;
-        gap: 6px;
         align-items: center;
-        font-size: 13px;
       }
-      #data button {
-        padding: 3px 9px;
-        font: inherit;
-        cursor: pointer;
+      .drawer__label {
+        font-family: var(--display);
+        font-weight: 600;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        font-size: 12px;
+        color: var(--ink-dim);
+        margin-right: 4px;
       }
-      #data textarea {
+      .drawer__status {
+        font-size: 12px;
+        color: var(--ink-dim);
+      }
+      .drawer textarea {
         width: 100%;
-        height: 92px;
+        height: 150px;
         box-sizing: border-box;
+        background: var(--bg);
+        color: var(--ink);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 8px;
         font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
         font-size: 12px;
         resize: vertical;
-      }
-      #stage {
-        flex: 1;
-        min-height: 0;
       }
     </style>
   </head>
   <body>
     <div id="app">
-      <header>
-        <span>Playmaker Playground</span>
-        <div id="controls"></div>
-        <span id="status" style="margin-left: auto; opacity: 0.7"></span>
-      </header>
-      <section id="data">
-        <div class="row">
-          <strong>PlayData JSON</strong>
-          <button id="json-export" type="button">現在の図を JSON へ書き出す</button>
-          <button id="json-import" type="button">JSON を読み込む（往復）</button>
-          <button id="json-legacy" type="button">版なし旧 blob を再現</button>
-          <button id="json-future" type="button">未来版(v99) blob を再現</button>
-          <span id="data-status" style="opacity: 0.7"></span>
+      <header class="topbar">
+        <div class="brand">
+          <span class="brand__name">Playmaker</span>
+          <span class="brand__tag">プレー図デザイナー — デモ</span>
         </div>
-        <textarea id="json" spellcheck="false" aria-label="PlayData JSON"></textarea>
+        <div class="topbar__spacer"></div>
+        <div class="topbar__actions">
+          <button id="mode-toggle" class="btn" type="button">view モードへ</button>
+          <button id="clear" class="btn" type="button">クリア</button>
+          <button id="export-png" class="btn" type="button">PNG 出力</button>
+          <button id="dev-toggle" class="btn" type="button" aria-pressed="false">開発者</button>
+        </div>
+      </header>
+
+      <div class="body">
+        <aside class="library">
+          <div id="library-scroll" class="library__scroll"></div>
+          <div class="playinfo">
+            <div class="playinfo__eyebrow">Now showing</div>
+            <div id="playinfo-name" class="playinfo__name">—</div>
+            <div class="playinfo__meta">
+              <span id="playinfo-chip" class="playinfo__chip" hidden></span>
+              <span id="playinfo-pers" class="playinfo__pers"></span>
+            </div>
+            <p id="playinfo-summary" class="playinfo__summary"></p>
+          </div>
+        </aside>
+
+        <main class="stage-wrap">
+          <div id="stage"></div>
+        </main>
+      </div>
+
+      <section id="drawer" class="drawer" aria-label="開発者ツール">
+        <div class="drawer__inner">
+          <div class="drawer__row">
+            <span class="drawer__label">Fixtures</span>
+            <button id="load-stress" class="btn" type="button">密度ストレス (選手22+線20)</button>
+            <span id="status" class="drawer__status"></span>
+          </div>
+          <div class="drawer__row">
+            <span class="drawer__label">PlayData JSON</span>
+            <button id="json-export" class="btn" type="button">書き出す</button>
+            <button id="json-import" class="btn" type="button">読み込む（往復）</button>
+            <button id="json-legacy" class="btn" type="button">版なし旧 blob</button>
+            <button id="json-future" class="btn" type="button">未来版(v99) blob</button>
+            <span id="data-status" class="drawer__status"></span>
+          </div>
+          <textarea id="json" spellcheck="false" aria-label="PlayData JSON"></textarea>
+        </div>
       </section>
-      <div id="stage"></div>
     </div>
     <script type="module" src="/main.ts"></script>
   </body>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,158 +1,64 @@
-// ローカル確認用 playground のエントリ。手元のブラウザで以下を目視する:
-// - フィールド描画とゾーン切替、2 形状（丸/四角）・色・ラベルの選手、route/block/motion の線
-// - 内蔵 UI（ツールバー/プロパティパネル/Undo·Redo/ゾーン切替）での編集と view/edit 切替
-// - フォーメーション読込（内蔵プルダウンと公開 API loadFormation の追記セマンティクス）
-// - PNG エクスポート（編集 UI を含まない・view/edit で同一図）
-// - PlayData 往復: getPlayData 書き出し → setPlayData 読込、版なし/未来版 blob が
-//   migratePlayData で現行版へ寄ること。編集すると onChange で JSON も更新される
-// - 密度ストレス（選手 22 + 線 20）: PRD 6.2「典型的フォーメーションを遅延なく」を
-//   手動目視するための fixture（戦術記法の厳密さは PRD 4.1 のとおり狙わない）
+// ローカル確認用 playground のエントリ。「Sideline Slate」筐体で以下を目視する:
+// - 左レールのプリセット・ライブラリ（フォーメーション 13・プレー図 16）をワンクリック読込
+// - 中央フィールドでの内蔵 UI（ツールバー/プロパティパネル）編集と view/edit 切替
+// - PNG エクスポート（編集 UI を含まない）
+// - 開発者ドロワー: PlayData 往復（getPlayData→setPlayData・版なし/未来版の migration）と
+//   密度ストレス（選手 22 + 線 20）を手動目視する fixture
 import {
   CURRENT_PLAY_DATA_VERSION,
   FORMATION_PRESETS,
+  type Formation,
   type Line,
+  PLAY_PRESETS,
+  type PlayCategory,
   type PlayData,
   type Player,
   Playmaker,
   type PlaymakerMode,
   type PlaymakerOptions,
+  type PlayPreset,
 } from "playmaker";
 
-const stage = document.getElementById("stage");
-const controlsEl = document.getElementById("controls");
-const statusEl = document.getElementById("status");
-const jsonEl = document.getElementById("json");
-const dataStatusEl = document.getElementById("data-status");
-if (
-  !stage ||
-  !controlsEl ||
-  !statusEl ||
-  !(jsonEl instanceof HTMLTextAreaElement) ||
-  !dataStatusEl
-) {
-  throw new Error("#stage / #controls / #status / #json / #data-status が見つかりません");
+function need<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (el === null) {
+    throw new Error(`#${id} が見つかりません`);
+  }
+  return el as T;
 }
-const controls: HTMLElement = controlsEl;
-const status: HTMLElement = statusEl;
-const mountPoint: HTMLElement = stage;
-const jsonArea: HTMLTextAreaElement = jsonEl;
-const dataStatus: HTMLElement = dataStatusEl;
 
-// 目視用サンプル: 2 形状（丸/四角）・色・ラベル・3 線種・直線/ベジェ・waypoint。
+const mountPoint = need("stage");
+const libraryScroll = need("library-scroll");
+const statusEl = need("status");
+const jsonArea = need<HTMLTextAreaElement>("json");
+const dataStatus = need("data-status");
+const infoName = need("playinfo-name");
+const infoChip = need("playinfo-chip");
+const infoPers = need("playinfo-pers");
+const infoSummary = need("playinfo-summary");
+
+// 静的 HTML のボタン/コンテナは HMR を跨いで生き残る。signal でリスナを束ねて再読込時に
+// 外し、コンテナは作り直す前に空にする（束ねないとホットリロードごとに多重登録される）。
+const demoLifetime = new AbortController();
+const { signal } = demoLifetime;
+
 const DEFENSE_COLOR = "#8f4034";
-const SAMPLE_PLAYERS: Player[] = [
-  { id: "ol-c", position: { lateralYard: 26.7, absoluteYard: 49 }, shape: "square", label: "C" },
-  { id: "ol-lg", position: { lateralYard: 24.4, absoluteYard: 49 }, shape: "square", label: "LG" },
-  { id: "ol-rg", position: { lateralYard: 29, absoluteYard: 49 }, shape: "square", label: "RG" },
-  { id: "ol-lt", position: { lateralYard: 22.1, absoluteYard: 49 }, shape: "square", label: "LT" },
-  { id: "ol-rt", position: { lateralYard: 31.3, absoluteYard: 49 }, shape: "square", label: "RT" },
-  { id: "qb", position: { lateralYard: 26.7, absoluteYard: 46.5 }, shape: "circle", label: "QB" },
-  { id: "rb", position: { lateralYard: 26.7, absoluteYard: 43 }, shape: "circle", label: "RB" },
-  { id: "wr-x", position: { lateralYard: 7, absoluteYard: 49.5 }, shape: "circle", label: "X" },
-  { id: "wr-z", position: { lateralYard: 46, absoluteYard: 49.5 }, shape: "circle", label: "Z" },
-  { id: "wr-y", position: { lateralYard: 38, absoluteYard: 48 }, shape: "circle", label: "Y" },
-  { id: "te", position: { lateralYard: 33.6, absoluteYard: 49 }, shape: "square", label: "TE" },
-  {
-    id: "dl-1",
-    position: { lateralYard: 24.4, absoluteYard: 51 },
-    shape: "circle",
-    label: "",
-    color: DEFENSE_COLOR,
-  },
-  {
-    id: "dl-2",
-    position: { lateralYard: 29, absoluteYard: 51 },
-    shape: "circle",
-    label: "",
-    color: DEFENSE_COLOR,
-  },
-  {
-    id: "lb-m",
-    position: { lateralYard: 26.7, absoluteYard: 54 },
-    shape: "circle",
-    label: "M",
-    color: DEFENSE_COLOR,
-  },
-  {
-    id: "cb-1",
-    position: { lateralYard: 7, absoluteYard: 53 },
-    shape: "circle",
-    label: "",
-    color: DEFENSE_COLOR,
-  },
-  {
-    id: "cb-2",
-    position: { lateralYard: 46, absoluteYard: 53 },
-    shape: "circle",
-    label: "",
-    color: DEFENSE_COLOR,
-  },
-  {
-    id: "fs",
-    position: { lateralYard: 26.7, absoluteYard: 60 },
-    shape: "circle",
-    label: "FS",
-    color: DEFENSE_COLOR,
-  },
-];
 
-const SAMPLE_LINES: Line[] = [
-  {
-    id: "rt-x",
-    kind: "route",
-    startPlayerId: "wr-x",
-    waypoints: [{ lateralYard: 7, absoluteYard: 59 }],
-    end: { lateralYard: 13, absoluteYard: 59 },
-    interpolation: "straight",
-  },
-  {
-    id: "rt-z",
-    kind: "route",
-    startPlayerId: "wr-z",
-    waypoints: [
-      { lateralYard: 46, absoluteYard: 58 },
-      { lateralYard: 43, absoluteYard: 60 },
-    ],
-    end: { lateralYard: 44, absoluteYard: 56 },
-    interpolation: "bezier",
-  },
-  {
-    id: "rt-y",
-    kind: "route",
-    startPlayerId: "wr-y",
-    waypoints: [{ lateralYard: 36, absoluteYard: 54 }],
-    end: { lateralYard: 18, absoluteYard: 61 },
-    interpolation: "bezier",
-  },
-  {
-    id: "bl-rt",
-    kind: "block",
-    startPlayerId: "ol-rt",
-    waypoints: [],
-    end: { lateralYard: 29.5, absoluteYard: 50.6 },
-    interpolation: "straight",
-  },
-  {
-    id: "bl-lt",
-    kind: "block",
-    startPlayerId: "ol-lt",
-    waypoints: [],
-    end: { lateralYard: 24, absoluteYard: 50.6 },
-    interpolation: "straight",
-    color: "#90caf9",
-  },
-  {
-    id: "mo-rb",
-    kind: "motion",
-    startPlayerId: "rb",
-    waypoints: [{ lateralYard: 33, absoluteYard: 44 }],
-    end: { lateralYard: 41, absoluteYard: 46 },
-    interpolation: "straight",
-  },
-];
+// タイプ分類 → コールシート色タグ（ラン/パス/RPO/カバレッジ/プレッシャー）。
+const CATEGORY_META: Record<PlayCategory, { label: string; color: string }> = {
+  "run-zone": { label: "RUN", color: "var(--cat-run)" },
+  "run-gap": { label: "RUN", color: "var(--cat-run)" },
+  "pass-quick": { label: "PASS", color: "var(--cat-pass)" },
+  "pass-dropback": { label: "PASS", color: "var(--cat-pass)" },
+  "pass-deep": { label: "PASS", color: "var(--cat-pass)" },
+  pa: { label: "PA", color: "var(--cat-pass)" },
+  rpo: { label: "RPO", color: "var(--cat-rpo)" },
+  coverage: { label: "COV", color: "var(--cat-cov)" },
+  pressure: { label: "PRES", color: "var(--cat-pres)" },
+};
 
-// 密度ストレス用 fixture。PRD 6.2 を手動目視するため demo に常設し、戦術的厳密さは狙わずに
-// 2 形状（丸/四角）・3 線種・straight/bezier・複数 waypoint を 1 ロードで漏れなく確認できる配置にする。
+// 密度ストレス用 fixture（選手 22 + 線 20）。PRD 6.2 を手動目視するため demo に常設し、
+// 2 形状（丸/四角）・3 線種・straight/bezier・複数 waypoint を 1 ロードで漏れなく確認する。
 const STRESS_PLAYERS: Player[] = [
   { id: "ol-c", position: { lateralYard: 26.7, absoluteYard: 49 }, shape: "square", label: "C" },
   { id: "ol-lg", position: { lateralYard: 24.4, absoluteYard: 49 }, shape: "square", label: "LG" },
@@ -285,7 +191,6 @@ const STRESS_LINES: Line[] = [
     end: { lateralYard: 31.7, absoluteYard: 50.6 },
     interpolation: "straight",
   },
-  // rt-te だけ color を持たせて route の色オーバーライドも 1 ロードで目視できるようにする。
   {
     id: "rt-x",
     kind: "route",
@@ -338,7 +243,6 @@ const STRESS_LINES: Line[] = [
     end: { lateralYard: 30, absoluteYard: 47.5 },
     interpolation: "straight",
   },
-  // 守備サイドの線は color に DEFENSE_COLOR を載せて攻守を一望できる色分けに揃える。
   {
     id: "pr-de-l",
     kind: "route",
@@ -427,21 +331,265 @@ let changeCount = 0;
 
 function onChange(data: PlayData): void {
   changeCount += 1;
-  status.textContent = `onChange #${changeCount}｜選手 ${data.players.length}・線 ${data.lines.length}・ゾーン ${data.field.zone}`;
-  // version の現行確定を編集ごとに目視できるよう通知データをそのまま出す。
+  statusEl.textContent = `onChange #${changeCount}｜選手 ${data.players.length}・線 ${data.lines.length}・ゾーン ${data.field.zone}`;
   jsonArea.value = JSON.stringify(data, null, 2);
 }
 
-/** 現在のプレー図（正準スナップショット）を JSON 欄へ書き出す。 */
 function refreshJson(): void {
   jsonArea.value = JSON.stringify(playmaker.getPlayData(), null, 2);
 }
 
-/**
- * JSON 欄の内容を setPlayData で読み込み、結果を再表示する。
- * setPlayData は onChange を発火しない契約なので明示的に書き戻し、版なし/未来版
- * blob が現行版へ寄る（migratePlayData）ことを往復として目視できる。
- */
+function create(initialData?: PlayData): Playmaker {
+  changeCount = 0;
+  statusEl.textContent = "onChange 待ち（編集すると更新されます）";
+  const options: PlaymakerOptions = { mode, onChange };
+  if (initialData !== undefined) {
+    options.initialData = initialData;
+  }
+  return new Playmaker(mountPoint, options);
+}
+
+let playmaker = create(PLAY_PRESETS[0]?.data);
+
+// ---- 左レール: プリセット・ライブラリ ----
+let activeButton: HTMLButtonElement | null = null;
+
+function setActive(button: HTMLButtonElement): void {
+  activeButton?.classList.remove("is-active");
+  button.classList.add("is-active");
+  activeButton = button;
+}
+
+function setInfo(
+  name: string,
+  chip: { label: string; color: string } | null,
+  pers: string,
+  summary: string,
+): void {
+  infoName.textContent = name;
+  if (chip === null) {
+    infoChip.hidden = true;
+  } else {
+    infoChip.hidden = false;
+    infoChip.textContent = chip.label;
+    infoChip.style.background = chip.color;
+  }
+  infoPers.textContent = pers;
+  infoSummary.textContent = summary;
+}
+
+function presetButton(name: string, tag: string, tagColor: string): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "preset";
+  const tagEl = document.createElement("span");
+  tagEl.className = "preset__tag";
+  tagEl.textContent = tag;
+  tagEl.style.background = tagColor;
+  const nameEl = document.createElement("span");
+  nameEl.className = "preset__name";
+  nameEl.textContent = name;
+  button.append(tagEl, nameEl);
+  return button;
+}
+
+function groupTitle(text: string): HTMLElement {
+  const el = document.createElement("div");
+  el.className = "group__title";
+  el.textContent = text;
+  return el;
+}
+
+function subTitle(text: string, offense: boolean): HTMLElement {
+  const el = document.createElement("div");
+  el.className = offense ? "group__sub group__sub--off" : "group__sub";
+  el.textContent = text;
+  return el;
+}
+
+function loadFormation(formation: Formation): void {
+  const players: Player[] = formation.players.map((p, i) => ({ ...p, id: `${formation.id}-${i}` }));
+  playmaker.setPlayData({
+    version: CURRENT_PLAY_DATA_VERSION,
+    field: { zone: playmaker.fieldZone },
+    players,
+    lines: [],
+  });
+  refreshJson();
+}
+
+function loadPlay(preset: PlayPreset): void {
+  playmaker.setPlayData(preset.data);
+  refreshJson();
+}
+
+interface PresetRow {
+  name: string;
+  tag: string;
+  tagColor: string;
+  select: () => void;
+}
+
+// 1 行ぶんの見た目と読込処理を item から導く（フォーメーション/プレー図で差分はここだけ）。
+function addSection<T extends { id: string; side: "offense" | "defense" }>(
+  items: readonly T[],
+  side: "offense" | "defense",
+  label: string,
+  toRow: (item: T) => PresetRow,
+): void {
+  const matching = items.filter((it) => it.side === side);
+  if (matching.length === 0) {
+    return;
+  }
+  libraryScroll.append(subTitle(label, side === "offense"));
+  for (const item of matching) {
+    const row = toRow(item);
+    const button = presetButton(row.name, row.tag, row.tagColor);
+    button.dataset.presetId = item.id;
+    button.addEventListener("click", () => {
+      setActive(button);
+      row.select();
+    });
+    libraryScroll.append(button);
+  }
+}
+
+function formationRow(formation: Formation): PresetRow {
+  const offense = formation.side === "offense";
+  return {
+    name: formation.name,
+    tag: offense ? "OFF" : "DEF",
+    tagColor: offense ? "var(--off)" : "var(--def)",
+    select: () => {
+      loadFormation(formation);
+      setInfo(
+        formation.name,
+        null,
+        "Formation",
+        "選手配置のみ（ライン無し）。現在の図を差し替えます。",
+      );
+    },
+  };
+}
+
+function playRow(preset: PlayPreset): PresetRow {
+  const meta = CATEGORY_META[preset.category];
+  return {
+    name: preset.name,
+    tag: meta.label,
+    tagColor: meta.color,
+    select: () => {
+      loadPlay(preset);
+      setInfo(preset.name, meta, preset.personnel, preset.summary);
+    },
+  };
+}
+
+libraryScroll.replaceChildren();
+libraryScroll.append(groupTitle("Formations"));
+addSection(FORMATION_PRESETS, "offense", "Offense", formationRow);
+addSection(FORMATION_PRESETS, "defense", "Defense", formationRow);
+libraryScroll.append(groupTitle("Plays"));
+addSection(PLAY_PRESETS, "offense", "Offense", playRow);
+addSection(PLAY_PRESETS, "defense", "Defense", playRow);
+
+// 初期表示は先頭プレー図に同期する（左レールのハイライトと Play info も合わせる）。
+const initialPreset = PLAY_PRESETS[0];
+if (initialPreset !== undefined) {
+  const initialButton = libraryScroll.querySelector<HTMLButtonElement>(
+    `[data-preset-id="${initialPreset.id}"]`,
+  );
+  if (initialButton !== null) {
+    setActive(initialButton);
+    const meta = CATEGORY_META[initialPreset.category];
+    setInfo(initialPreset.name, meta, initialPreset.personnel, initialPreset.summary);
+  }
+}
+
+// ---- トップバー ----
+const modeButton = need<HTMLButtonElement>("mode-toggle");
+modeButton.addEventListener(
+  "click",
+  () => {
+    // mode 切替は再マウント（現在のプレー図はそのまま引き継ぐ）。
+    const snapshot = playmaker.getPlayData();
+    playmaker.dispose();
+    mode = mode === "edit" ? "view" : "edit";
+    playmaker = create(snapshot);
+    syncModeButton();
+    refreshJson();
+  },
+  { signal },
+);
+
+function syncModeButton(): void {
+  modeButton.textContent = mode === "edit" ? "view モードへ" : "edit モードへ";
+  modeButton.setAttribute("aria-pressed", String(mode === "view"));
+}
+syncModeButton();
+
+need<HTMLButtonElement>("clear").addEventListener(
+  "click",
+  () => {
+    playmaker.setPlayData({
+      version: CURRENT_PLAY_DATA_VERSION,
+      field: { zone: playmaker.fieldZone },
+      players: [],
+      lines: [],
+    });
+    refreshJson();
+    activeButton?.classList.remove("is-active");
+    activeButton = null;
+    setInfo("—", null, "", "");
+  },
+  { signal },
+);
+
+need<HTMLButtonElement>("export-png").addEventListener(
+  "click",
+  async () => {
+    const blob = await playmaker.exportToPng();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `playmaker-${mode}-${Date.now()}.png`;
+    a.click();
+    // click() のダウンロードは環境により非同期。同期 revoke で取りこぼす環境があるため遅延する。
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+    statusEl.textContent = `PNG 出力（${mode} モード・${Math.round(blob.size / 1024)}KB）`;
+  },
+  { signal },
+);
+
+const drawer = need("drawer");
+const devToggle = need<HTMLButtonElement>("dev-toggle");
+devToggle.addEventListener(
+  "click",
+  () => {
+    const open = drawer.classList.toggle("is-open");
+    devToggle.setAttribute("aria-pressed", String(open));
+  },
+  { signal },
+);
+
+// ---- 開発者ドロワー: 往復・migration・密度ストレスの目視 ----
+need<HTMLButtonElement>("load-stress").addEventListener(
+  "click",
+  () => {
+    playmaker.setPlayData({
+      version: CURRENT_PLAY_DATA_VERSION,
+      field: { zone: playmaker.fieldZone },
+      players: STRESS_PLAYERS,
+      lines: STRESS_LINES,
+    });
+    refreshJson();
+    activeButton?.classList.remove("is-active");
+    activeButton = null;
+    setInfo("密度ストレス", null, "選手 22・線 20", "描画・操作の体感速度を手動目視する fixture。");
+  },
+  { signal },
+);
+
 function loadFromJsonText(): void {
   let parsed: unknown;
   try {
@@ -456,126 +604,40 @@ function loadFromJsonText(): void {
   dataStatus.textContent = "読込完了（version は現行へ寄せて再表示）";
 }
 
-function create(initialData?: PlayData): Playmaker {
-  changeCount = 0;
-  status.textContent = "onChange 待ち（編集すると更新されます）";
-  // exactOptionalPropertyTypes: initialData は値があるときだけ持たせる。
-  const options: PlaymakerOptions = { mode, onChange };
-  if (initialData !== undefined) {
-    options.initialData = initialData;
-  }
-  return new Playmaker(mountPoint, options);
-}
-
-let playmaker = create({
-  version: CURRENT_PLAY_DATA_VERSION,
-  field: { zone: "middle" },
-  players: SAMPLE_PLAYERS,
-  lines: SAMPLE_LINES,
-});
-
-function addAction(label: string, onClick: () => void): HTMLButtonElement {
-  const button = document.createElement("button");
-  button.textContent = label;
-  button.addEventListener("click", onClick);
-  controls.appendChild(button);
-  return button;
-}
-
-// version/field zone/refreshJson 忘れを防ぐためボタンの差し替え軸（players/lines）だけ受ける。
-function loadScene(players: Player[], lines: Line[]): void {
-  playmaker.setPlayData({
-    version: CURRENT_PLAY_DATA_VERSION,
-    field: { zone: playmaker.fieldZone },
-    players,
-    lines,
-  });
-  refreshJson();
-}
-
-addAction("サンプル隊形＋線を読み込む", () => loadScene(SAMPLE_PLAYERS, SAMPLE_LINES));
-addAction("クリア", () => loadScene([], []));
-// 密度ストレス（選手 22 + 線 20）。PRD 6.2「典型的フォーメーションを遅延なく」を
-// このボタン 1 つで読み込み、描画・ゾーン切替・操作の体感速度を手動目視する。
-addAction("密度ストレス (選手22+線20)", () => loadScene(STRESS_PLAYERS, STRESS_LINES));
-
-// 公開 API loadFormation の目視（追記）。クリア→攻→守 の順で重ねられる。
-for (const formation of FORMATION_PRESETS) {
-  addAction(`＋${formation.name}`, () => playmaker.loadFormation(formation));
-}
-
-// PNG エクスポート（PRD 5.7）。出力に編集 UI（ツール/パネル/選択/ハンドル）が
-// 含まれないこと・view/edit いずれでも出せることを目視する。
-addAction("PNG を出力", async () => {
-  const blob = await playmaker.exportToPng();
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = `playmaker-${mode}-${Date.now()}.png`;
-  a.click();
-  // click() のダウンロード処理はブラウザにより非同期。同期 revoke すると
-  // 取得開始前に URL が失効しダウンロードを取りこぼす環境があるため遅延する。
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
-  status.textContent = `PNG 出力（${mode} モード・${Math.round(blob.size / 1024)}KB）`;
-});
-
-const modeButton = addAction("", () => {
-  // mode 切替は再マウント（現在のプレー図はそのまま引き継ぐ）。
-  const snapshot = playmaker.getPlayData();
-  playmaker.dispose();
-  mode = mode === "edit" ? "view" : "edit";
-  playmaker = create(snapshot);
-  syncModeButton();
-  refreshJson();
-});
-
-function syncModeButton(): void {
-  modeButton.textContent = mode === "edit" ? "view モードへ" : "edit モードへ";
-  modeButton.setAttribute("aria-pressed", String(mode === "view"));
-}
-
-syncModeButton();
-
-// JSON パネル（往復・migration の目視）。静的 HTML のボタンに結線する。
-// 静的 HTML ボタンは HMR を跨いで生き残るため、signal でリスナを束ね再読込時に外す
-// （束ねないとホットリロードごとに多重登録され 1 クリックで多重発火する）。
-const demoLifetime = new AbortController();
-
-function bindButton(id: string, onClick: () => void): void {
-  const button = document.getElementById(id);
-  if (!(button instanceof HTMLButtonElement)) {
-    throw new Error(`#${id} が見つかりません`);
-  }
-  button.addEventListener("click", onClick, { signal: demoLifetime.signal });
-}
-
-/** 任意 blob を JSON 欄へ流し込み読込まで通す（旧版/未来版 fixture の目視に共通）。 */
 function loadFixture(blob: unknown): void {
   jsonArea.value = JSON.stringify(blob, null, 2);
   loadFromJsonText();
 }
 
-bindButton("json-export", () => {
-  refreshJson();
-  dataStatus.textContent = "現在の getPlayData を書き出し";
-});
-bindButton("json-import", loadFromJsonText);
-// version フィールドの無い商用ソフト初期データ → 読込で現行版へ寄る。
-bindButton("json-legacy", () =>
-  loadFixture({
-    field: { zone: "own-redzone" },
-    players: [{ id: "wr", position: { lateralYard: 5, absoluteYard: 50 }, shape: "square" }],
-  }),
+need<HTMLButtonElement>("json-export").addEventListener(
+  "click",
+  () => {
+    refreshJson();
+    dataStatus.textContent = "現在の getPlayData を書き出し";
+  },
+  { signal },
 );
-// 新しい lib で保存された未来版 → 前方互換で現行へ寄り未知項目は落ちる。
-bindButton("json-future", () =>
-  loadFixture({
-    version: 99,
-    field: { zone: "redzone" },
-    players: [{ id: "qb", position: { lateralYard: 26, absoluteYard: 48 }, shape: "circle" }],
-    lines: [],
-    futureOnlyField: { whatever: true },
-  }),
+need<HTMLButtonElement>("json-import").addEventListener("click", loadFromJsonText, { signal });
+need<HTMLButtonElement>("json-legacy").addEventListener(
+  "click",
+  () =>
+    loadFixture({
+      field: { zone: "own-redzone" },
+      players: [{ id: "wr", position: { lateralYard: 5, absoluteYard: 50 }, shape: "square" }],
+    }),
+  { signal },
+);
+need<HTMLButtonElement>("json-future").addEventListener(
+  "click",
+  () =>
+    loadFixture({
+      version: 99,
+      field: { zone: "redzone" },
+      players: [{ id: "qb", position: { lateralYard: 26, absoluteYard: 48 }, shape: "circle" }],
+      lines: [],
+      futureOnlyField: { whatever: true },
+    }),
+  { signal },
 );
 
 refreshJson();

--- a/src/browser/rendering/player-renderer.ts
+++ b/src/browser/rendering/player-renderer.ts
@@ -40,6 +40,12 @@ const SHAPE_ROTATION: Record<Exclude<PlayerShape, "circle">, number> = {
   hexagon: 0,
 };
 
+// 円は外接円半径そのままだと多角形（外接円に内接＝辺が内側）より一回り大きく見え、
+// マーカーが動線（特に LOS 際のブロック）を覆う。描画半径だけ正方形の辺幅へ寄せて
+// 視覚的な大きさを揃える（錯視で円は小さく見えるためやや大きめ）。当たり領域は全形状で
+// 外接円のまま＝hit-test の一様性（player.ts の不変条件）は崩さない。
+const CIRCLE_DRAW_SCALE = 0.82;
+
 export class PlayerRenderer {
   /**
    * players を配列順（後の要素ほど上）に描く。
@@ -67,7 +73,7 @@ export class PlayerRenderer {
       // 影・グラデーションを持たない完全フラット。塗り → 枠線の順で描く。
       ctx.beginPath();
       if (player.shape === "circle") {
-        ctx.arc(x, y, r, 0, Math.PI * 2);
+        ctx.arc(x, y, r * CIRCLE_DRAW_SCALE, 0, Math.PI * 2);
       } else {
         this.tracePolygon(ctx, x, y, r, player.shape);
       }

--- a/src/common/formations/presets.test.ts
+++ b/src/common/formations/presets.test.ts
@@ -4,12 +4,12 @@ import { isFormationSide, normalizeFormation } from "./formation.js";
 import { FORMATION_PRESETS, getFormationPreset } from "./presets.js";
 
 describe("FORMATION_PRESETS データ健全性", () => {
-  it("攻 2・守 2 の 4 プリセットで id は一意", () => {
-    expect(FORMATION_PRESETS).toHaveLength(4);
+  it("攻 7・守 6 の 13 プリセットで id は一意", () => {
+    expect(FORMATION_PRESETS).toHaveLength(13);
     const ids = FORMATION_PRESETS.map((f) => f.id);
     expect(new Set(ids).size).toBe(ids.length);
-    expect(FORMATION_PRESETS.filter((f) => f.side === "offense")).toHaveLength(2);
-    expect(FORMATION_PRESETS.filter((f) => f.side === "defense")).toHaveLength(2);
+    expect(FORMATION_PRESETS.filter((f) => f.side === "offense")).toHaveLength(7);
+    expect(FORMATION_PRESETS.filter((f) => f.side === "defense")).toHaveLength(6);
   });
 
   it("各プリセットは 11 人・side/shape/位置が妥当・攻守で色付けが分かれる", () => {
@@ -31,6 +31,17 @@ describe("FORMATION_PRESETS データ健全性", () => {
     }
   });
 
+  it("各プリセットは middle ゾーン窓 (abs 35..65) とフィールド幅に収まる", () => {
+    for (const formation of FORMATION_PRESETS) {
+      for (const p of formation.players) {
+        expect(p.position.absoluteYard).toBeGreaterThanOrEqual(35);
+        expect(p.position.absoluteYard).toBeLessThanOrEqual(65);
+        expect(p.position.lateralYard).toBeGreaterThanOrEqual(0);
+        expect(p.position.lateralYard).toBeLessThanOrEqual(53.3);
+      }
+    }
+  });
+
   it("各プリセットは公開境界の normalizeFormation を通過し選手数を保つ", () => {
     for (const formation of FORMATION_PRESETS) {
       const normalized = normalizeFormation(formation);
@@ -42,7 +53,7 @@ describe("FORMATION_PRESETS データ健全性", () => {
 
 describe("getFormationPreset", () => {
   it("既知 id は該当プリセット、未知 id は undefined", () => {
-    expect(getFormationPreset("i-formation")?.name).toBe("I フォーメーション");
+    expect(getFormationPreset("i-formation")?.name).toBe("I-Formation");
     expect(getFormationPreset("defense-nickel")?.side).toBe("defense");
     expect(getFormationPreset("does-not-exist")).toBeUndefined();
   });

--- a/src/common/formations/presets.ts
+++ b/src/common/formations/presets.ts
@@ -1,12 +1,13 @@
 // 組み込み済みプリセットフォーメーション（PRD 5.6「オフェンス・ディフェンスの代表的な隊形」）。
-// DOM 非依存のデータ。座標はヤード空間（LOS≈50・センター lat≈26.7）で middle ゾーン窓
-// (abs 35..65) に収まるよう置く。戦術的厳密性より組み込みやすさ優先（PRD 4.1）＝代表例に絞る。
+// DOM 非依存のデータ。座標はヤード空間（LOS≈50・センター lat≈26.7・ダウンフィールド=abs 増加）で
+// middle ゾーン窓 (abs 35..65) に収まるよう置く。名称は現代アメフトの英語表記で統一する
+// （フィールド上の表記＝英語というプロダクト方針）。戦術的厳密性より組み込みやすさ優先（PRD 4.1）。
 
 import type { PlayerShape } from "../model/player.js";
 import type { Formation, FormationPlayer } from "./formation.js";
 
-/** ディフェンス選手の既定色（攻守を一目で区別できるよう、くすませた赤）。 */
-const DEFENSE_COLOR = "#8f4034";
+/** ディフェンス選手の既定色（攻守を一目で区別できるよう、くすませた赤）。プレー図プリセットでも共有する。 */
+export const DEFENSE_COLOR = "#8f4034";
 
 /** オフェンス選手テンプレート（色なし＝テーマ既定）。 */
 function off(
@@ -28,7 +29,7 @@ function def(
   return { position: { lateralYard, absoluteYard }, shape, label, color: DEFENSE_COLOR };
 }
 
-// オフェンスライン（5 人・LOS 上）は両隊形で共通。
+// オフェンスライン（5 人・LOS 上）は全隊形で共通。
 const OFFENSIVE_LINE: FormationPlayer[] = [
   off("LT", 22.1, 49.5, "square"),
   off("LG", 24.4, 49.5, "square"),
@@ -37,85 +38,242 @@ const OFFENSIVE_LINE: FormationPlayer[] = [
   off("RT", 31.3, 49.5, "square"),
 ];
 
-// ディフェンスライン（4 人）は両隊形で共通。
-const DEFENSIVE_LINE: FormationPlayer[] = [
-  def("", 21, 51, "circle"),
-  def("", 24.5, 51, "circle"),
+// 4 ダウンの守備ライン（オーバーフロント）。4-3 系・ニッケル・ダイム・4-2-5 で共通。
+const FRONT_4: FormationPlayer[] = [
+  def("", 21.5, 51, "circle"),
+  def("", 24.4, 51, "circle"),
   def("", 29, 51, "circle"),
-  def("", 32.5, 51, "circle"),
+  def("", 31.9, 51, "circle"),
+];
+
+// 3 ダウンの守備ライン（オッドフロント）。3-4・3-3-5 で共通。
+const FRONT_3: FormationPlayer[] = [
+  def("", 23, 51, "circle"),
+  def("", 26.7, 51, "circle"),
+  def("", 30.4, 51, "circle"),
 ];
 
 const I_FORMATION: Formation = {
   id: "i-formation",
-  name: "I フォーメーション",
+  name: "I-Formation",
   side: "offense",
   players: [
     ...OFFENSIVE_LINE,
-    off("TE", 33.6, 49.5, "square"),
+    off("Y", 33.6, 49.5, "square"),
     off("QB", 26.7, 47.5, "circle"),
     off("FB", 26.7, 45, "circle"),
     off("RB", 26.7, 42.5, "circle"),
-    off("X", 7, 49.5, "circle"),
-    off("Z", 46, 49.5, "circle"),
+    off("X", 6.5, 49.5, "circle"),
+    off("Z", 46.5, 49, "circle"),
+  ],
+};
+
+const SINGLEBACK_ACE: Formation = {
+  id: "singleback-ace",
+  name: "Singleback Ace",
+  side: "offense",
+  players: [
+    ...OFFENSIVE_LINE,
+    off("Y", 33.6, 49.5, "square"),
+    off("QB", 26.7, 47.5, "circle"),
+    off("RB", 26.7, 43.5, "circle"),
+    off("X", 6, 49.5, "circle"),
+    off("H", 40, 48.5, "circle"),
+    off("Z", 47, 49, "circle"),
   ],
 };
 
 const SHOTGUN_SPREAD: Formation = {
   id: "shotgun-spread",
-  name: "ショットガン スプレッド",
+  name: "Shotgun Spread",
   side: "offense",
   players: [
     ...OFFENSIVE_LINE,
     off("QB", 26.7, 45, "circle"),
-    off("RB", 29.7, 45, "circle"),
-    off("X", 6, 49.5, "circle"),
+    off("RB", 29.5, 45, "circle"),
+    off("X", 5.5, 49.5, "circle"),
     off("Y", 13, 49, "circle"),
     off("H", 40, 49, "circle"),
-    off("Z", 47, 49.5, "circle"),
+    off("Z", 47.5, 49.5, "circle"),
+  ],
+};
+
+const TRIPS: Formation = {
+  id: "trips",
+  name: "Trips",
+  side: "offense",
+  players: [
+    ...OFFENSIVE_LINE,
+    off("QB", 26.7, 45, "circle"),
+    off("RB", 24, 45, "circle"),
+    off("X", 5.5, 49.5, "circle"),
+    off("Y", 34.5, 49, "square"),
+    off("H", 41, 48.5, "circle"),
+    off("Z", 47.5, 49, "circle"),
+  ],
+};
+
+const EMPTY: Formation = {
+  id: "empty",
+  name: "Empty",
+  side: "offense",
+  players: [
+    ...OFFENSIVE_LINE,
+    off("QB", 26.7, 45, "circle"),
+    off("X", 5, 49.5, "circle"),
+    off("F", 12, 48.5, "circle"),
+    off("Y", 34.5, 49, "square"),
+    off("H", 41, 48.5, "circle"),
+    off("Z", 48, 49, "circle"),
+  ],
+};
+
+const PISTOL: Formation = {
+  id: "pistol",
+  name: "Pistol",
+  side: "offense",
+  players: [
+    ...OFFENSIVE_LINE,
+    off("Y", 33.6, 49.5, "square"),
+    off("QB", 26.7, 45.5, "circle"),
+    off("RB", 26.7, 42.5, "circle"),
+    off("X", 6, 49.5, "circle"),
+    off("H", 40, 48.5, "circle"),
+    off("Z", 47, 49, "circle"),
+  ],
+};
+
+const BUNCH: Formation = {
+  id: "bunch",
+  name: "Bunch",
+  side: "offense",
+  players: [
+    ...OFFENSIVE_LINE,
+    off("QB", 26.7, 45, "circle"),
+    off("RB", 24, 45, "circle"),
+    off("X", 5.5, 49.5, "circle"),
+    off("Z", 37, 49, "circle"),
+    off("H", 34.3, 47.8, "circle"),
+    off("Y", 39.7, 47.8, "circle"),
   ],
 };
 
 const DEFENSE_4_3: Formation = {
   id: "defense-4-3",
-  name: "4-3 ディフェンス",
+  name: "4-3",
   side: "defense",
   players: [
-    ...DEFENSIVE_LINE,
-    def("S", 20, 54.5, "circle"),
-    def("M", 26.7, 54.5, "circle"),
-    def("W", 33, 54.5, "circle"),
+    ...FRONT_4,
+    def("W", 22, 54, "circle"),
+    def("M", 26.7, 54, "circle"),
+    def("S", 31.4, 54, "circle"),
     def("", 7, 53, "circle"),
     def("", 46, 53, "circle"),
-    def("FS", 22, 60, "circle"),
-    def("SS", 31, 60, "circle"),
+    def("FS", 24, 59, "circle"),
+    def("SS", 30, 58, "circle"),
+  ],
+};
+
+const DEFENSE_3_4: Formation = {
+  id: "defense-3-4",
+  name: "3-4",
+  side: "defense",
+  players: [
+    ...FRONT_3,
+    def("W", 19, 53, "circle"),
+    def("M", 24.5, 54, "circle"),
+    def("T", 29, 54, "circle"),
+    def("S", 34.5, 53, "circle"),
+    def("", 7, 53, "circle"),
+    def("", 46, 53, "circle"),
+    def("FS", 24, 59, "circle"),
+    def("SS", 30, 59, "circle"),
   ],
 };
 
 const DEFENSE_NICKEL: Formation = {
   id: "defense-nickel",
-  name: "ニッケル ディフェンス",
+  name: "Nickel",
   side: "defense",
   players: [
-    ...DEFENSIVE_LINE,
-    def("M", 23, 54.5, "circle"),
-    def("W", 31, 54.5, "circle"),
-    def("N", 14, 55, "circle"),
+    ...FRONT_4,
+    def("M", 23.5, 54, "circle"),
+    def("W", 31, 54, "circle"),
+    def("N", 14, 54.5, "circle"),
     def("", 7, 53, "circle"),
     def("", 46, 53, "circle"),
-    def("FS", 22, 60, "circle"),
-    def("SS", 31, 60, "circle"),
+    def("FS", 22, 59.5, "circle"),
+    def("SS", 31, 59.5, "circle"),
+  ],
+};
+
+const DEFENSE_DIME: Formation = {
+  id: "defense-dime",
+  name: "Dime",
+  side: "defense",
+  players: [
+    ...FRONT_4,
+    def("M", 26.7, 54, "circle"),
+    def("N", 14, 54, "circle"),
+    def("$", 39, 54, "circle"),
+    def("", 7, 53, "circle"),
+    def("", 46, 53, "circle"),
+    def("FS", 22, 59, "circle"),
+    def("SS", 31, 59, "circle"),
+  ],
+};
+
+const DEFENSE_4_2_5: Formation = {
+  id: "defense-4-2-5",
+  name: "4-2-5",
+  side: "defense",
+  players: [
+    ...FRONT_4,
+    def("M", 24.5, 54, "circle"),
+    def("W", 30, 54, "circle"),
+    def("N", 39, 54.5, "circle"),
+    def("", 7, 53, "circle"),
+    def("", 46, 53, "circle"),
+    def("FS", 24, 59, "circle"),
+    def("SS", 30, 58, "circle"),
+  ],
+};
+
+const DEFENSE_3_3_5: Formation = {
+  id: "defense-3-3-5",
+  name: "3-3-5",
+  side: "defense",
+  players: [
+    ...FRONT_3,
+    def("W", 20, 54, "circle"),
+    def("M", 26.7, 54, "circle"),
+    def("S", 33, 54, "circle"),
+    def("N", 14, 54.5, "circle"),
+    def("", 7, 53, "circle"),
+    def("", 46, 53, "circle"),
+    def("FS", 24, 59, "circle"),
+    def("SS", 30, 58, "circle"),
   ],
 };
 
 /**
- * 組み込みプリセット一覧（攻 2・守 2）。Toolbar はこれを攻守でグループ表示し、
+ * 組み込みプリセット一覧（攻 7・守 6）。Toolbar はこれを攻守でグループ表示し、
  * 商用ソフトはこの配列を起点に独自テンプレートを足せる（PRD 5.6）。
  */
 export const FORMATION_PRESETS: readonly Formation[] = [
   I_FORMATION,
+  SINGLEBACK_ACE,
   SHOTGUN_SPREAD,
+  TRIPS,
+  EMPTY,
+  PISTOL,
+  BUNCH,
   DEFENSE_4_3,
+  DEFENSE_3_4,
   DEFENSE_NICKEL,
+  DEFENSE_DIME,
+  DEFENSE_4_2_5,
+  DEFENSE_3_3_5,
 ];
 
 /** id でプリセットを引く。未知 id は undefined（呼び出し側で無視する）。 */

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -136,6 +136,8 @@ export {
   type Player,
   type PlayerShape,
 } from "./model/player.js";
+export type { PlayCategory, PlayPreset } from "./plays/play-preset.js";
+export { getPlayPreset, PLAY_PRESETS } from "./plays/presets.js";
 export {
   type IUndoRedoService,
   UndoRedoService,

--- a/src/common/plays/play-preset.ts
+++ b/src/common/plays/play-preset.ts
@@ -1,0 +1,40 @@
+// プレー図プリセットのデータ表現。Formation（配置のみ・線なし）と異なり、
+// ルート/ブロック/モーションの線を含む完成したプレー図（PlayData）に、一覧・分類用の
+// メタ情報を添えたもの。`data` はそのまま `setPlayData` へ渡して読み込める。
+// 名称は現代アメフトの英語表記、説明は日本語（フィールド表記＝英語というプロダクト方針）。
+
+import type { FormationSide } from "../formations/formation.js";
+import type { PlayData } from "../model/play-data.js";
+
+/**
+ * プレーのタイプ分類。一覧をコールシート風の色タグで束ねるための意味情報で、
+ * 実際の配色は demo（UI 層）がこの値に対応づける（common に配色を持ち込まない）。
+ */
+export type PlayCategory =
+  | "run-zone"
+  | "run-gap"
+  | "pass-quick"
+  | "pass-dropback"
+  | "pass-deep"
+  | "pa"
+  | "rpo"
+  | "coverage"
+  | "pressure";
+
+/** プレー図プリセット。`data` は setPlayData で復元できる完成プレー図。 */
+export interface PlayPreset {
+  /** 安定識別子（UI の選択値）。 */
+  id: string;
+  /** 表示名（英語のフットボール用語）。 */
+  name: string;
+  /** 攻守（一覧の UI グルーピング用）。 */
+  side: FormationSide;
+  /** タイプ分類（コールシート色タグ）。 */
+  category: PlayCategory;
+  /** パーソネル/隊形の短い注記（例: "11 pers" / "Nickel"）。 */
+  personnel: string;
+  /** コンセプトの一行説明（日本語・UI 用）。 */
+  summary: string;
+  /** そのまま setPlayData へ渡せるプレー図データ。 */
+  data: PlayData;
+}

--- a/src/common/plays/presets.test.ts
+++ b/src/common/plays/presets.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { isFormationSide } from "../formations/formation.js";
+import { isLineInterpolation, isLineKind } from "../model/line.js";
+import { CURRENT_PLAY_DATA_VERSION, resolvePlayData } from "../model/play-data.js";
+import { isPlayerShape } from "../model/player.js";
+import type { PlayCategory } from "./play-preset.js";
+import { getPlayPreset, PLAY_PRESETS } from "./presets.js";
+
+const DEFENSE_COLOR = "#8f4034";
+const VALID_CATEGORIES: readonly PlayCategory[] = [
+  "run-zone",
+  "run-gap",
+  "pass-quick",
+  "pass-dropback",
+  "pass-deep",
+  "pa",
+  "rpo",
+  "coverage",
+  "pressure",
+];
+
+function inWindow(lateralYard: number, absoluteYard: number): boolean {
+  return absoluteYard >= 35 && absoluteYard <= 65 && lateralYard >= 0 && lateralYard <= 53.3;
+}
+
+describe("PLAY_PRESETS データ健全性", () => {
+  it("攻 10・守 8 の 18 プリセットで id は一意", () => {
+    expect(PLAY_PRESETS).toHaveLength(18);
+    const ids = PLAY_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(PLAY_PRESETS.filter((p) => p.side === "offense")).toHaveLength(10);
+    expect(PLAY_PRESETS.filter((p) => p.side === "defense")).toHaveLength(8);
+  });
+
+  it("各プリセットのメタ情報と field は妥当", () => {
+    for (const preset of PLAY_PRESETS) {
+      expect(isFormationSide(preset.side)).toBe(true);
+      expect(VALID_CATEGORIES).toContain(preset.category);
+      expect(preset.name.trim()).not.toBe("");
+      expect(preset.personnel.trim()).not.toBe("");
+      expect(preset.summary.trim()).not.toBe("");
+      expect(preset.data.version).toBe(CURRENT_PLAY_DATA_VERSION);
+      expect(preset.data.field.zone).toBe("middle");
+    }
+  });
+
+  it("各プリセットは攻守 22 人・id 一意・色付けが攻守で分かれ、全員が窓内に収まる", () => {
+    for (const preset of PLAY_PRESETS) {
+      const players = preset.data.players;
+      expect(players).toHaveLength(22);
+      const ids = players.map((p) => p.id);
+      expect(new Set(ids).size).toBe(ids.length);
+      for (const p of players) {
+        expect(isPlayerShape(p.shape)).toBe(true);
+        expect(inWindow(p.position.lateralYard, p.position.absoluteYard)).toBe(true);
+        // 守は赤で塗り、攻は色なし（テーマ既定）。
+        expect(p.color === DEFENSE_COLOR || p.color === undefined).toBe(true);
+      }
+    }
+  });
+
+  it("各線は実在選手を起点にし、種別・補間・座標が妥当で、攻守の色分けに従う", () => {
+    for (const preset of PLAY_PRESETS) {
+      const playerIds = new Set(preset.data.players.map((p) => p.id));
+      for (const line of preset.data.lines) {
+        expect(playerIds.has(line.startPlayerId)).toBe(true);
+        expect(isLineKind(line.kind)).toBe(true);
+        expect(isLineInterpolation(line.interpolation)).toBe(true);
+        expect(line.color === DEFENSE_COLOR || line.color === undefined).toBe(true);
+        for (const point of [...line.waypoints, line.end]) {
+          expect(inWindow(point.lateralYard, point.absoluteYard)).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("各プリセットの data は resolvePlayData を通過し選手・線を 1 つも落とさない", () => {
+    for (const preset of PLAY_PRESETS) {
+      const resolved = resolvePlayData(preset.data);
+      expect(resolved.players).toHaveLength(preset.data.players.length);
+      expect(resolved.lines).toHaveLength(preset.data.lines.length);
+    }
+  });
+});
+
+describe("getPlayPreset", () => {
+  it("既知 id は該当プリセット、未知 id は undefined", () => {
+    expect(getPlayPreset("play-inside-zone")?.name).toBe("Inside Zone");
+    expect(getPlayPreset("play-cover-3")?.side).toBe("defense");
+    expect(getPlayPreset("does-not-exist")).toBeUndefined();
+  });
+});

--- a/src/common/plays/presets.ts
+++ b/src/common/plays/presets.ts
@@ -1,0 +1,690 @@
+// 組み込み済みプリセットプレー図（攻 9・守 7）。現代アメフト（NFL/カレッジ）の代表的な
+// ラン/パス/RPO/カバレッジ/プレッシャー概念を 1 枚ずつ収める。DOM 非依存のデータ。
+// 座標はヤード空間（LOS≈50・ダウンフィールド=abs 増加・センター lat≈26.7）で middle ゾーン窓
+// (abs 35..65) に収まる。主役側のみがルート/ブロック/モーションを持ち、相手側は配置マーカーだけ。
+
+import type { FormationSide } from "../formations/formation.js";
+import { DEFENSE_COLOR } from "../formations/presets.js";
+import type { Line, LineInterpolation, LineKind } from "../model/line.js";
+import { CURRENT_PLAY_DATA_VERSION } from "../model/play-data.js";
+import type { FieldPosition, Player, PlayerShape } from "../model/player.js";
+import type { PlayCategory, PlayPreset } from "./play-preset.js";
+
+function pt(lateralYard: number, absoluteYard: number): FieldPosition {
+  return { lateralYard, absoluteYard };
+}
+
+/** オフェンス選手（色なし＝テーマ既定）。 */
+function oP(id: string, label: string, lat: number, abs: number, shape: PlayerShape): Player {
+  return { id, position: { lateralYard: lat, absoluteYard: abs }, shape, label };
+}
+
+/** ディフェンス選手（丸・DEFENSE_COLOR）。 */
+function dP(id: string, label: string, lat: number, abs: number): Player {
+  return {
+    id,
+    position: { lateralYard: lat, absoluteYard: abs },
+    shape: "circle",
+    label,
+    color: DEFENSE_COLOR,
+  };
+}
+
+/** 線 1 本。色は任意（オフェンス=テーマ既定で省略、ディフェンス=DEFENSE_COLOR）。 */
+function ln(
+  id: string,
+  kind: LineKind,
+  startPlayerId: string,
+  waypoints: FieldPosition[],
+  end: FieldPosition,
+  interpolation: LineInterpolation,
+  color?: string,
+): Line {
+  const line: Line = { id, kind, startPlayerId, waypoints, end, interpolation };
+  if (color !== undefined) {
+    line.color = color;
+  }
+  return line;
+}
+
+function play(
+  id: string,
+  name: string,
+  side: FormationSide,
+  category: PlayCategory,
+  personnel: string,
+  summary: string,
+  players: Player[],
+  lines: Line[],
+): PlayPreset {
+  return {
+    id,
+    name,
+    side,
+    category,
+    personnel,
+    summary,
+    data: { version: CURRENT_PLAY_DATA_VERSION, field: { zone: "middle" }, players, lines },
+  };
+}
+
+// オフェンスライン 5 人（全プレー共通）。
+function ol(): Player[] {
+  return [
+    oP("lt", "LT", 22.1, 49.5, "square"),
+    oP("lg", "LG", 24.4, 49.5, "square"),
+    oP("c", "C", 26.7, 49.5, "square"),
+    oP("rg", "RG", 29, 49.5, "square"),
+    oP("rt", "RT", 31.3, 49.5, "square"),
+  ];
+}
+
+// ニッケル系（4 ダウン＋ILB 2 枚）の共通前 6 枚。CB・ニッケル・セイフティは呼び出し側で足す
+// （カバレッジ/プレッシャーごとに DB の置き方が変わるため、変動分だけを各所で明示する）。
+function nickelFront(): Player[] {
+  return [
+    dP("de-l", "", 21.5, 51),
+    dP("dt-l", "", 24.4, 51),
+    dP("dt-r", "", 29, 51),
+    dP("de-r", "", 31.9, 51),
+    dP("mlb", "M", 23.5, 54),
+    dP("wlb", "W", 31, 54),
+  ];
+}
+
+// 相手側（脇役）の配置のみ。線は持たせない。攻のプレー図ではこのフロントを添える。
+function defLook43(): Player[] {
+  return [
+    dP("de-l", "", 21.5, 51),
+    dP("dt-l", "", 24.4, 51),
+    dP("dt-r", "", 29, 51),
+    dP("de-r", "", 31.9, 51),
+    dP("wlb", "W", 22, 54),
+    dP("mlb", "M", 26.7, 54),
+    dP("slb", "S", 31.4, 54),
+    dP("cb-l", "", 7, 53),
+    dP("cb-r", "", 46, 53),
+    dP("fs", "FS", 24, 59),
+    dP("ss", "SS", 30, 58),
+  ];
+}
+
+function defLookNickel(): Player[] {
+  return [
+    ...nickelFront(),
+    dP("nb", "N", 14, 54.5),
+    dP("cb-l", "", 7, 53),
+    dP("cb-r", "", 46, 53),
+    dP("fs", "FS", 22, 59.5),
+    dP("ss", "SS", 31, 59.5),
+  ];
+}
+
+function defLookCover2(): Player[] {
+  return [
+    ...nickelFront(),
+    dP("nb", "N", 14, 54),
+    dP("cb-l", "", 7, 52.5),
+    dP("cb-r", "", 46, 52.5),
+    dP("fs", "FS", 18, 60),
+    dP("ss", "SS", 35, 60),
+  ];
+}
+
+function defLookCover3(): Player[] {
+  return [
+    ...nickelFront(),
+    dP("nb", "N", 14, 54.5),
+    dP("cb-l", "", 7, 53),
+    dP("cb-r", "", 46, 53),
+    dP("fs", "FS", 26.7, 60),
+    dP("ss", "SS", 33, 55),
+  ];
+}
+
+// オフェンスの配置のみ（守のプレー図ではこの 2x2 を脇役として添える）。
+function offLook(): Player[] {
+  return [
+    ...ol(),
+    oP("qb", "QB", 26.7, 45, "circle"),
+    oP("rb", "RB", 29.5, 45, "circle"),
+    oP("x", "X", 5.5, 49.5, "circle"),
+    oP("y", "Y", 13, 49, "circle"),
+    oP("h", "H", 40, 49, "circle"),
+    oP("z", "Z", 47.5, 49.5, "circle"),
+  ];
+}
+
+const INSIDE_ZONE = play(
+  "play-inside-zone",
+  "Inside Zone",
+  "offense",
+  "run-zone",
+  "11 pers",
+  "ゾーンブロックで内側を一気に。RB はバックサイド A ギャップを読んで切る。",
+  [
+    ...ol(),
+    oP("y", "Y", 33.6, 49.5, "square"),
+    oP("qb", "QB", 26.7, 45, "circle"),
+    oP("rb", "RB", 24, 45, "circle"),
+    oP("x", "X", 6, 49.5, "circle"),
+    oP("h", "H", 40, 48.5, "circle"),
+    oP("z", "Z", 47, 49, "circle"),
+    ...defLook43(),
+  ],
+  [
+    ln("bl-lt", "block", "lt", [], pt(22.9, 50.8), "straight"),
+    ln("bl-lg", "block", "lg", [], pt(25.2, 50.8), "straight"),
+    ln("bl-c", "block", "c", [], pt(27.5, 50.8), "straight"),
+    ln("bl-rg", "block", "rg", [], pt(30, 50.8), "straight"),
+    ln("bl-rt", "block", "rt", [], pt(32.2, 50.8), "straight"),
+    ln("bl-y", "block", "y", [], pt(35, 50.8), "straight"),
+    ln("run-rb", "route", "rb", [pt(26.5, 48.5)], pt(28.5, 53), "bezier"),
+  ],
+);
+
+const OUTSIDE_ZONE = play(
+  "play-outside-zone",
+  "Outside Zone",
+  "offense",
+  "run-zone",
+  "11 pers",
+  "ワイドゾーンで横へ伸ばし、エッジを攻めて縦に切り返す。",
+  [
+    ...ol(),
+    oP("y", "Y", 33.6, 49.5, "square"),
+    oP("qb", "QB", 26.7, 47.5, "circle"),
+    oP("rb", "RB", 26.7, 43.5, "circle"),
+    oP("x", "X", 6, 49.5, "circle"),
+    oP("h", "H", 40, 48.5, "circle"),
+    oP("z", "Z", 47, 49, "circle"),
+    ...defLook43(),
+  ],
+  [
+    ln("bl-lt", "block", "lt", [], pt(23.5, 50.6), "straight"),
+    ln("bl-lg", "block", "lg", [], pt(26, 50.6), "straight"),
+    ln("bl-c", "block", "c", [], pt(28, 50.6), "straight"),
+    ln("bl-rg", "block", "rg", [], pt(30.5, 50.6), "straight"),
+    ln("bl-rt", "block", "rt", [], pt(33, 50.7), "straight"),
+    ln("bl-y", "block", "y", [], pt(35.5, 50.6), "straight"),
+    ln("run-rb", "route", "rb", [pt(31, 45.5), pt(34, 48.5)], pt(35.5, 53), "bezier"),
+  ],
+);
+
+const POWER = play(
+  "play-power",
+  "Power",
+  "offense",
+  "run-gap",
+  "21 pers",
+  "プレイサイドはダウンブロック、バックサイドガードがプルしてリードする。",
+  [
+    ...ol(),
+    oP("y", "Y", 33.6, 49.5, "square"),
+    oP("qb", "QB", 26.7, 47.5, "circle"),
+    oP("fb", "FB", 26.7, 45, "circle"),
+    oP("rb", "RB", 26.7, 42.5, "circle"),
+    oP("x", "X", 6.5, 49.5, "circle"),
+    oP("z", "Z", 46.5, 49, "circle"),
+    ...defLook43(),
+  ],
+  [
+    ln("bl-rg", "block", "rg", [], pt(30.5, 50.6), "straight"),
+    ln("bl-rt", "block", "rt", [], pt(33, 50.6), "straight"),
+    ln("bl-y", "block", "y", [], pt(35.5, 50.6), "straight"),
+    ln("bl-c", "block", "c", [], pt(25.5, 50.5), "straight"),
+    ln("bl-lt", "block", "lt", [], pt(21.5, 50), "straight"),
+    ln("pull-lg", "block", "lg", [pt(27, 48.5)], pt(33, 51.5), "bezier"),
+    ln("lead-fb", "block", "fb", [], pt(34, 50.5), "straight"),
+    ln("run-rb", "route", "rb", [pt(29, 45)], pt(33.5, 51), "bezier"),
+  ],
+);
+
+const COUNTER = play(
+  "play-counter",
+  "Counter (GT)",
+  "offense",
+  "run-gap",
+  "21 pers",
+  "バックサイドのガードとタックルがプルし、逆方向へ折り返す（GT カウンター）。",
+  [
+    ...ol(),
+    oP("y", "Y", 33.6, 49.5, "square"),
+    oP("qb", "QB", 26.7, 47.5, "circle"),
+    oP("fb", "FB", 26.7, 45, "circle"),
+    oP("rb", "RB", 26.7, 42.5, "circle"),
+    oP("x", "X", 6.5, 49.5, "circle"),
+    oP("z", "Z", 46.5, 49, "circle"),
+    ...defLook43(),
+  ],
+  [
+    ln("bl-c", "block", "c", [], pt(28, 50.6), "straight"),
+    ln("bl-rg", "block", "rg", [], pt(30.5, 50.6), "straight"),
+    ln("bl-rt", "block", "rt", [], pt(33, 50.6), "straight"),
+    ln("bl-y", "block", "y", [], pt(35.5, 50.6), "straight"),
+    ln("pull-lg", "block", "lg", [pt(28, 49)], pt(34.5, 50.8), "bezier"),
+    ln("pull-lt", "block", "lt", [pt(27, 48.5)], pt(33, 52.5), "bezier"),
+    ln("fill-fb", "block", "fb", [], pt(24, 49.5), "straight"),
+    ln("run-rb", "route", "rb", [pt(24, 43.5), pt(29, 46)], pt(34, 51), "bezier"),
+  ],
+);
+
+const FOUR_VERTICALS = play(
+  "play-four-verticals",
+  "Four Verticals",
+  "offense",
+  "pass-deep",
+  "10 pers",
+  "トリップスから 4 本の縦。対シングルハイのシームで勝負する。",
+  [
+    ...ol(),
+    oP("qb", "QB", 26.7, 45, "circle"),
+    oP("rb", "RB", 24, 45, "circle"),
+    oP("x", "X", 5.5, 49.5, "circle"),
+    oP("y", "Y", 34.5, 49, "square"),
+    oP("h", "H", 41, 48.5, "circle"),
+    oP("z", "Z", 47.5, 49, "circle"),
+    ...defLookCover3(),
+  ],
+  [
+    ln("go-x", "route", "x", [], pt(6, 63), "straight"),
+    ln("seam-y", "route", "y", [pt(33, 55)], pt(31, 63), "bezier"),
+    ln("seam-h", "route", "h", [pt(40, 55)], pt(38, 63), "bezier"),
+    ln("go-z", "route", "z", [], pt(47.5, 63), "straight"),
+    ln("chk-rb", "route", "rb", [], pt(20, 47), "straight"),
+  ],
+);
+
+const MESH = play(
+  "play-mesh",
+  "Mesh",
+  "offense",
+  "pass-dropback",
+  "10 pers",
+  "浅いクロスの交差。対マン/ゾーン両対応で空いた所へ運ぶ。",
+  [
+    ...ol(),
+    oP("qb", "QB", 26.7, 45, "circle"),
+    oP("rb", "RB", 29.5, 45, "circle"),
+    oP("x", "X", 5.5, 49.5, "circle"),
+    oP("y", "Y", 13, 49, "circle"),
+    oP("h", "H", 40, 49, "circle"),
+    oP("z", "Z", 47.5, 49.5, "circle"),
+    ...defLookNickel(),
+  ],
+  [
+    ln("cross-y", "route", "y", [pt(20, 51.5)], pt(38, 52), "bezier"),
+    ln("cross-h", "route", "h", [pt(33, 51)], pt(15, 52), "bezier"),
+    ln("corner-x", "route", "x", [pt(5, 55)], pt(2, 59), "bezier"),
+    ln("sit-z", "route", "z", [], pt(47, 55), "straight"),
+    ln("swing-rb", "route", "rb", [pt(33, 46)], pt(41, 48), "bezier"),
+  ],
+);
+
+const SMASH = play(
+  "play-smash",
+  "Smash",
+  "offense",
+  "pass-dropback",
+  "11 pers",
+  "コーナー＋ヒッチのハイロー。対カバー 2 のコーナーを攻める。",
+  [
+    ...ol(),
+    oP("y", "Y", 33.6, 49.5, "square"),
+    oP("qb", "QB", 26.7, 47.5, "circle"),
+    oP("rb", "RB", 26.7, 43.5, "circle"),
+    oP("x", "X", 6, 49.5, "circle"),
+    oP("h", "H", 40, 48.5, "circle"),
+    oP("z", "Z", 47, 49, "circle"),
+    ...defLookCover2(),
+  ],
+  [
+    ln("hitch-z", "route", "z", [], pt(47, 53), "straight"),
+    ln("corner-h", "route", "h", [pt(41, 54)], pt(46, 60), "bezier"),
+    ln("dig-y", "route", "y", [pt(31, 53)], pt(27, 57), "bezier"),
+    ln("hitch-x", "route", "x", [], pt(6, 53), "straight"),
+    ln("flat-rb", "route", "rb", [], pt(22, 46), "straight"),
+  ],
+);
+
+const STICK = play(
+  "play-stick",
+  "Stick",
+  "offense",
+  "pass-quick",
+  "11 pers",
+  "3 ステップの速攻。スティック（座り）＋フラットで素早く配球する。",
+  [
+    ...ol(),
+    oP("y", "Y", 33.6, 49.5, "square"),
+    oP("qb", "QB", 26.7, 47.5, "circle"),
+    oP("rb", "RB", 26.7, 43.5, "circle"),
+    oP("x", "X", 6, 49.5, "circle"),
+    oP("h", "H", 40, 48.5, "circle"),
+    oP("z", "Z", 47, 49, "circle"),
+    ...defLookNickel(),
+  ],
+  [
+    ln("stick-y", "route", "y", [], pt(33, 53.5), "straight"),
+    ln("flat-h", "route", "h", [], pt(45, 50), "straight"),
+    ln("hitch-z", "route", "z", [], pt(47, 53), "straight"),
+    ln("slant-x", "route", "x", [pt(6, 52)], pt(10, 53), "bezier"),
+    ln("chk-rb", "route", "rb", [], pt(21, 45), "straight"),
+  ],
+);
+
+const RPO_BUBBLE = play(
+  "play-rpo-bubble",
+  "RPO (IZ + Bubble)",
+  "offense",
+  "rpo",
+  "11 pers",
+  "ボックスの人数を読み、インサイドゾーンかバブルへ分岐する。",
+  [
+    ...ol(),
+    oP("qb", "QB", 26.7, 45, "circle"),
+    oP("rb", "RB", 29.5, 45, "circle"),
+    oP("x", "X", 5.5, 49.5, "circle"),
+    oP("y", "Y", 13, 49, "circle"),
+    oP("h", "H", 40, 49, "circle"),
+    oP("z", "Z", 47.5, 49.5, "circle"),
+    ...defLookNickel(),
+  ],
+  [
+    ln("bl-lt", "block", "lt", [], pt(22.9, 50.8), "straight"),
+    ln("bl-lg", "block", "lg", [], pt(25.2, 50.8), "straight"),
+    ln("bl-c", "block", "c", [], pt(27.5, 50.8), "straight"),
+    ln("bl-rg", "block", "rg", [], pt(30, 50.8), "straight"),
+    ln("bl-rt", "block", "rt", [], pt(32.2, 50.8), "straight"),
+    ln("run-rb", "route", "rb", [pt(27, 48)], pt(26, 52.5), "bezier"),
+    ln("bubble-h", "route", "h", [pt(43, 48)], pt(46, 50.5), "bezier"),
+    ln("bl-z", "block", "z", [], pt(45, 52), "straight"),
+    ln("glance-y", "route", "y", [pt(15, 51.5)], pt(19, 53), "bezier"),
+  ],
+);
+
+const PA_BOOT = play(
+  "play-pa-boot",
+  "PA Boot (Sail)",
+  "offense",
+  "pa",
+  "11 pers",
+  "プレイアクションで QB がブートし、フラット/セイル/縦の 3 段で攻める。",
+  [
+    ...ol(),
+    oP("y", "Y", 33.6, 49.5, "square"),
+    oP("qb", "QB", 26.7, 47.5, "circle"),
+    oP("rb", "RB", 26.7, 43.5, "circle"),
+    oP("x", "X", 6, 49.5, "circle"),
+    oP("h", "H", 40, 48.5, "circle"),
+    oP("z", "Z", 47, 49, "circle"),
+    ...defLook43(),
+  ],
+  [
+    ln("fake-rb", "motion", "rb", [pt(24, 44.5)], pt(20, 46), "straight"),
+    ln("boot-qb", "route", "qb", [pt(31, 47.5)], pt(36.5, 46), "bezier"),
+    ln("bl-c", "block", "c", [], pt(27.5, 50.5), "straight"),
+    ln("bl-rg", "block", "rg", [], pt(30, 50.5), "straight"),
+    ln("flat-y", "route", "y", [pt(37, 49.5)], pt(43, 50.5), "bezier"),
+    ln("sail-h", "route", "h", [pt(41, 53)], pt(47, 56), "bezier"),
+    ln("go-z", "route", "z", [], pt(47.5, 62), "straight"),
+    ln("comeback-x", "route", "x", [pt(6, 58)], pt(9, 56), "bezier"),
+  ],
+);
+
+const COVER_1 = play(
+  "play-cover-1",
+  "Cover 1 (Man Free)",
+  "defense",
+  "coverage",
+  "Nickel",
+  "1 ディープのフリーセイフティを残し、残りは全マン。",
+  [
+    ...nickelFront(),
+    dP("nb", "N", 14, 54.5),
+    dP("cb-l", "", 7, 53),
+    dP("cb-r", "", 46, 53),
+    dP("fs", "FS", 26.7, 61),
+    dP("ss", "SS", 33, 55),
+    ...offLook(),
+  ],
+  [
+    ln("man-cbl", "motion", "cb-l", [], pt(5.5, 50.5), "straight", DEFENSE_COLOR),
+    ln("man-cbr", "motion", "cb-r", [], pt(47.5, 50.5), "straight", DEFENSE_COLOR),
+    ln("man-nb", "motion", "nb", [], pt(13, 50), "straight", DEFENSE_COLOR),
+    ln("man-ss", "motion", "ss", [pt(36, 52)], pt(40, 50), "straight", DEFENSE_COLOR),
+    ln("man-mlb", "motion", "mlb", [], pt(26.5, 47), "straight", DEFENSE_COLOR),
+    ln("free-fs", "motion", "fs", [], pt(26.7, 63), "straight", DEFENSE_COLOR),
+  ],
+);
+
+const COVER_2 = play(
+  "play-cover-2",
+  "Cover 2",
+  "defense",
+  "coverage",
+  "Nickel",
+  "2 ディープ 5 アンダーのゾーン。深いハーフを 2 人で分ける。",
+  [
+    ...nickelFront(),
+    dP("nb", "N", 14, 54),
+    dP("cb-l", "", 7, 52.5),
+    dP("cb-r", "", 46, 52.5),
+    dP("fs", "FS", 15, 60),
+    dP("ss", "SS", 38, 60),
+    ...offLook(),
+  ],
+  [
+    ln("half-fs", "motion", "fs", [], pt(13, 62), "straight", DEFENSE_COLOR),
+    ln("half-ss", "motion", "ss", [], pt(40, 62), "straight", DEFENSE_COLOR),
+    ln("flat-cbl", "motion", "cb-l", [], pt(10, 52), "straight", DEFENSE_COLOR),
+    ln("flat-cbr", "motion", "cb-r", [], pt(43, 52), "straight", DEFENSE_COLOR),
+    ln("hook-mlb", "motion", "mlb", [], pt(22, 52), "straight", DEFENSE_COLOR),
+    ln("hook-wlb", "motion", "wlb", [], pt(33, 52), "straight", DEFENSE_COLOR),
+    ln("curl-nb", "motion", "nb", [], pt(16, 53), "straight", DEFENSE_COLOR),
+  ],
+);
+
+const COVER_3 = play(
+  "play-cover-3",
+  "Cover 3",
+  "defense",
+  "coverage",
+  "Nickel",
+  "3 ディープ 4 アンダー。現代の基準となるシングルハイのゾーン。",
+  [
+    ...nickelFront(),
+    dP("nb", "N", 14, 54.5),
+    dP("cb-l", "", 7, 53),
+    dP("cb-r", "", 46, 53),
+    dP("fs", "FS", 26.7, 60),
+    dP("ss", "SS", 34, 55),
+    ...offLook(),
+  ],
+  [
+    ln("deep-cbl", "motion", "cb-l", [pt(7, 57)], pt(7, 62), "straight", DEFENSE_COLOR),
+    ln("deep-cbr", "motion", "cb-r", [], pt(46, 62), "straight", DEFENSE_COLOR),
+    ln("deep-fs", "motion", "fs", [], pt(26.7, 63), "straight", DEFENSE_COLOR),
+    ln("curl-nb", "motion", "nb", [], pt(15, 53), "straight", DEFENSE_COLOR),
+    ln("hook-mlb", "motion", "mlb", [], pt(22, 52), "straight", DEFENSE_COLOR),
+    ln("hook-wlb", "motion", "wlb", [], pt(33, 52), "straight", DEFENSE_COLOR),
+    ln("flat-ss", "motion", "ss", [], pt(38, 53), "straight", DEFENSE_COLOR),
+  ],
+);
+
+const COVER_4 = play(
+  "play-cover-4",
+  "Cover 4 (Quarters)",
+  "defense",
+  "coverage",
+  "Nickel",
+  "4 ディープのクォーターズ。縦パスを上から踏み潰す。",
+  [
+    ...nickelFront(),
+    dP("nb", "N", 14, 54.5),
+    dP("cb-l", "", 7, 53),
+    dP("cb-r", "", 46, 53),
+    dP("fs", "FS", 20, 59.5),
+    dP("ss", "SS", 33, 59.5),
+    ...offLook(),
+  ],
+  [
+    ln("qtr-cbl", "motion", "cb-l", [], pt(6, 62), "straight", DEFENSE_COLOR),
+    ln("qtr-cbr", "motion", "cb-r", [], pt(47, 62), "straight", DEFENSE_COLOR),
+    ln("qtr-fs", "motion", "fs", [], pt(18, 62), "straight", DEFENSE_COLOR),
+    ln("qtr-ss", "motion", "ss", [], pt(35, 62), "straight", DEFENSE_COLOR),
+    ln("under-nb", "motion", "nb", [], pt(15, 52), "straight", DEFENSE_COLOR),
+    ln("under-mlb", "motion", "mlb", [], pt(24, 52), "straight", DEFENSE_COLOR),
+    ln("under-wlb", "motion", "wlb", [], pt(31, 52), "straight", DEFENSE_COLOR),
+  ],
+);
+
+const FIRE_ZONE = play(
+  "play-fire-zone",
+  "Fire Zone",
+  "defense",
+  "pressure",
+  "Nickel",
+  "5 人ブリッツ＋ライン 1 枚をドロップ、3 ディープ 3 アンダーで覆う。",
+  [
+    ...nickelFront(),
+    dP("nb", "N", 14, 54.5),
+    dP("cb-l", "", 7, 53),
+    dP("cb-r", "", 46, 53),
+    dP("fs", "FS", 26.7, 60),
+    dP("ss", "SS", 34, 55),
+    ...offLook(),
+  ],
+  [
+    ln("rush-dtl", "route", "dt-l", [], pt(24, 49), "straight", DEFENSE_COLOR),
+    ln("rush-dtr", "route", "dt-r", [], pt(29.5, 49), "straight", DEFENSE_COLOR),
+    ln("rush-der", "route", "de-r", [], pt(32.5, 49), "straight", DEFENSE_COLOR),
+    ln("blz-wlb", "route", "wlb", [pt(30, 52)], pt(29, 49.5), "bezier", DEFENSE_COLOR),
+    ln("blz-nb", "route", "nb", [pt(16, 52)], pt(20, 49.5), "bezier", DEFENSE_COLOR),
+    ln("drop-del", "motion", "de-l", [pt(20, 53)], pt(18, 55), "straight", DEFENSE_COLOR),
+    ln("deep-cbl", "motion", "cb-l", [], pt(7, 61), "straight", DEFENSE_COLOR),
+    ln("deep-cbr", "motion", "cb-r", [], pt(46, 61), "straight", DEFENSE_COLOR),
+    ln("deep-fs", "motion", "fs", [], pt(26.7, 63), "straight", DEFENSE_COLOR),
+    ln("hook-mlb", "motion", "mlb", [], pt(24, 52), "straight", DEFENSE_COLOR),
+    ln("flat-ss", "motion", "ss", [], pt(37, 53), "straight", DEFENSE_COLOR),
+  ],
+);
+
+const COVER_0 = play(
+  "play-cover-0",
+  "Cover 0 Blitz",
+  "defense",
+  "pressure",
+  "Nickel",
+  "セイフティを残さず全マン、6 人で最大限の圧力をかける。",
+  [
+    ...nickelFront(),
+    dP("nb", "N", 14, 54.5),
+    dP("cb-l", "", 7, 52.5),
+    dP("cb-r", "", 46, 52.5),
+    dP("fs", "FS", 22, 59.5),
+    dP("ss", "SS", 31, 59.5),
+    ...offLook(),
+  ],
+  [
+    ln("rush-del", "route", "de-l", [], pt(21, 49), "straight", DEFENSE_COLOR),
+    ln("rush-dtl", "route", "dt-l", [], pt(24, 49), "straight", DEFENSE_COLOR),
+    ln("rush-dtr", "route", "dt-r", [], pt(29.5, 49), "straight", DEFENSE_COLOR),
+    ln("rush-der", "route", "de-r", [], pt(32.5, 49), "straight", DEFENSE_COLOR),
+    ln("blz-mlb", "route", "mlb", [pt(25, 51)], pt(26.5, 49), "bezier", DEFENSE_COLOR),
+    ln("blz-wlb", "route", "wlb", [pt(28, 52)], pt(28.5, 49.5), "bezier", DEFENSE_COLOR),
+    ln("man-cbl", "motion", "cb-l", [], pt(5.5, 50.5), "straight", DEFENSE_COLOR),
+    ln("man-cbr", "motion", "cb-r", [], pt(47.5, 50.5), "straight", DEFENSE_COLOR),
+    ln("man-nb", "motion", "nb", [], pt(13, 50), "straight", DEFENSE_COLOR),
+    ln("man-fs", "motion", "fs", [pt(26, 54)], pt(29, 48), "straight", DEFENSE_COLOR),
+    ln("man-ss", "motion", "ss", [], pt(40, 50), "straight", DEFENSE_COLOR),
+  ],
+);
+
+const DOUBLE_A = play(
+  "play-double-a",
+  "Double-A Gap",
+  "defense",
+  "pressure",
+  "Nickel",
+  "両 A ギャップに 2 人を提示。実行・シム（見せ）どちらにも化ける。",
+  [
+    ...nickelFront(),
+    dP("nb", "N", 14, 54.5),
+    dP("cb-l", "", 7, 53),
+    dP("cb-r", "", 46, 53),
+    dP("fs", "FS", 26.7, 60),
+    dP("ss", "SS", 34, 55),
+    ...offLook(),
+  ],
+  [
+    ln("aim-mlb", "route", "mlb", [pt(25, 52)], pt(25.8, 49.5), "bezier", DEFENSE_COLOR),
+    ln("aim-wlb", "route", "wlb", [pt(28, 52)], pt(27.6, 49.5), "bezier", DEFENSE_COLOR),
+    ln("rush-del", "route", "de-l", [], pt(21, 49), "straight", DEFENSE_COLOR),
+    ln("rush-dtl", "route", "dt-l", [], pt(24, 49), "straight", DEFENSE_COLOR),
+    ln("rush-dtr", "route", "dt-r", [], pt(29.5, 49), "straight", DEFENSE_COLOR),
+    ln("rush-der", "route", "de-r", [], pt(32.5, 49), "straight", DEFENSE_COLOR),
+    ln("bail-cbl", "motion", "cb-l", [], pt(7, 60), "straight", DEFENSE_COLOR),
+    ln("bail-cbr", "motion", "cb-r", [], pt(46, 60), "straight", DEFENSE_COLOR),
+    ln("deep-fs", "motion", "fs", [], pt(26.7, 62), "straight", DEFENSE_COLOR),
+    ln("curl-nb", "motion", "nb", [], pt(16, 53), "straight", DEFENSE_COLOR),
+    ln("flat-ss", "motion", "ss", [], pt(37, 53), "straight", DEFENSE_COLOR),
+  ],
+);
+
+const COVER_6 = play(
+  "play-cover-6",
+  "Cover 6",
+  "defense",
+  "coverage",
+  "Nickel",
+  "クォーター×2＋ハーフの分割カバー。フィールドはクォーターズ、バウンダリは 2。",
+  [
+    ...nickelFront(),
+    dP("nb", "N", 39, 54),
+    dP("cb-l", "", 7, 52.5),
+    dP("cb-r", "", 46, 53),
+    dP("fs", "FS", 15, 59.5),
+    dP("ss", "SS", 35, 55),
+    ...offLook(),
+  ],
+  [
+    ln("flat-cbl", "motion", "cb-l", [], pt(11, 52), "straight", DEFENSE_COLOR),
+    ln("half-fs", "motion", "fs", [], pt(12, 62), "straight", DEFENSE_COLOR),
+    ln("qtr-cbr", "motion", "cb-r", [], pt(47, 62), "straight", DEFENSE_COLOR),
+    ln("qtr-ss", "motion", "ss", [], pt(38, 62), "straight", DEFENSE_COLOR),
+    ln("curl-nb", "motion", "nb", [], pt(42, 53), "straight", DEFENSE_COLOR),
+    ln("hook-mlb", "motion", "mlb", [], pt(22, 52), "straight", DEFENSE_COLOR),
+    ln("hook-wlb", "motion", "wlb", [], pt(33, 52), "straight", DEFENSE_COLOR),
+  ],
+);
+
+/**
+ * 組み込みプレー図一覧（攻 10・守 8）。demo はこれを攻守・タイプで束ねて一覧表示し、
+ * 商用ソフトはこの配列を起点に独自プレーを足せる。
+ */
+export const PLAY_PRESETS: readonly PlayPreset[] = [
+  INSIDE_ZONE,
+  OUTSIDE_ZONE,
+  POWER,
+  COUNTER,
+  FOUR_VERTICALS,
+  MESH,
+  SMASH,
+  STICK,
+  RPO_BUBBLE,
+  PA_BOOT,
+  COVER_1,
+  COVER_2,
+  COVER_3,
+  COVER_4,
+  FIRE_ZONE,
+  COVER_0,
+  DOUBLE_A,
+  COVER_6,
+];
+
+/** id でプレー図プリセットを引く。未知 id は undefined（呼び出し側で無視する）。 */
+export function getPlayPreset(id: string): PlayPreset | undefined {
+  return PLAY_PRESETS.find((p) => p.id === id);
+}

--- a/src/playmaker.ts
+++ b/src/playmaker.ts
@@ -28,15 +28,19 @@ export type {
   Line,
   LineInterpolation,
   LineKind,
+  PlayCategory,
   PlayData,
   Player,
   PlayerShape,
+  PlayPreset,
 } from "./common/index.js";
 export {
   CURRENT_PLAY_DATA_VERSION,
   FORMATION_PRESETS,
   getFormationPreset,
+  getPlayPreset,
   migratePlayData,
+  PLAY_PRESETS,
 } from "./common/index.js";
 
 export type PlaymakerMode = "view" | "edit";


### PR DESCRIPTION
### Summary

demo を実用的なショーケースにするため、現代戦術のプリセットを大幅に拡充し、プレー図デザイナーのレイアウトを刷新する。<br>
あわせて円マーカーの描画サイズを見直し、動線の視認性を上げる。

### Checklist

- [x] Code builds and unit tests pass locally
- [ ] Relevant documentation updated
- [x] Reviewer has sufficient context

### Motivation and Context

既存 demo は操作しづらく、用意していた隊形・プレーも少数で「これだけ描ける」を示せていなかった。<br>
NFL/カレッジの現代戦術に沿ったプリセットを揃え、コーチツール風の筐体で一覧・読込できるようにする。

### Implementation Details

- フォーメーション 13 種・プレー図 18 種を `src/common/`（DOM 非依存）にプリセットとして追加し、配置・ライン整合を node 単体テストで担保（`src/common/**` の 100% カバレッジゲートは維持）。プレー図は新概念のため `PlayPreset`（= `PlayData` + メタ情報）型を新設し、公開 API から取得できるよう re-export。<br>
- 描画では円マーカーだけ描画半径を多角形と同等へ縮小（当たり領域は全形状で外接円のまま＝hit-test の一様性は不変）。LOS 際のブロック線が隠れる問題を解消。<br>
- demo を「Sideline Slate」レイアウトへ刷新。左レールのプリセット・ライブラリ＋ Play info、JSON・密度ストレス等は開発者ドロワーへ集約。ライブラリ内蔵 UI は構造変更せず据え置き。

### Testing Instructions

1. `pnpm run test`（typecheck/lint/build は `pnpm run typecheck` / `pnpm run lint` / `pnpm run build`）。<br>
2. `pnpm run dev` で左レールから各プリセットを読み込み、配置・動線・分類タグ・円マーカーの大きさを目視確認する。

### Related Issues

特になし。

### Notes for Release

特になし。
