### PR TITLE
feat(editing): 線の先端移動・作図確定の選択切替・線色パレットを整える

### DIFF
--- a/src/browser/rendering/canvas-surface.ts
+++ b/src/browser/rendering/canvas-surface.ts
@@ -176,7 +176,7 @@ export class CanvasSurface extends Disposable {
    * 位置計算は common のジオメトリに委譲し、ここは色と図形を置くだけ。
    */
   private drawOverlay(accent: string): void {
-    const { selectedPlayerId, selectedLineId, waypointHandles } = this.overlay;
+    const { selectedPlayerId, selectedLineId, waypointHandles, endpointHandle } = this.overlay;
 
     if (selectedPlayerId !== undefined) {
       const player = this.data.players.find((p) => p.id === selectedPlayerId);
@@ -221,15 +221,30 @@ export class CanvasSurface extends Disposable {
     // アイコンは hit 許容（WAYPOINT_HANDLE_RADIUS_YARDS）の一部だけを描く。フルに
     // 描くとマーカー並みに大きいので小さく出し、掴みやすさは hit 許容側に委ねる。
     const handleHalf = Math.max(3, 0.45 * WAYPOINT_HANDLE_RADIUS_YARDS * this.geometry.scale);
-    for (const wp of waypointHandles) {
-      const { x, y } = this.geometry.toCanvas(wp.lateralYard, wp.absoluteYard);
-      this.ctx.beginPath();
-      this.ctx.rect(x - handleHalf, y - handleHalf, handleHalf * 2, handleHalf * 2);
+    // 現在の path（beginPath 済み）をハンドル共通の塗り・白縁で仕上げる。
+    const paintHandle = () => {
       this.ctx.fillStyle = accent;
       this.ctx.fill();
       this.ctx.lineWidth = 1.5;
       this.ctx.strokeStyle = "rgba(255, 255, 255, 0.9)";
       this.ctx.stroke();
+    };
+    for (const wp of waypointHandles) {
+      const { x, y } = this.geometry.toCanvas(wp.lateralYard, wp.absoluteYard);
+      this.ctx.beginPath();
+      this.ctx.rect(x - handleHalf, y - handleHalf, handleHalf * 2, handleHalf * 2);
+      paintHandle();
+    }
+
+    // 終点ハンドルは waypoint（四角）と区別できるよう円で描く（先端の掴み所を明示）。
+    if (endpointHandle !== undefined) {
+      const { x, y } = this.geometry.toCanvas(
+        endpointHandle.lateralYard,
+        endpointHandle.absoluteYard,
+      );
+      this.ctx.beginPath();
+      this.ctx.arc(x, y, handleHalf + 1, 0, Math.PI * 2);
+      paintHandle();
     }
   }
 

--- a/src/browser/ui/property-panel.ts
+++ b/src/browser/ui/property-panel.ts
@@ -5,6 +5,8 @@
 import {
   Disposable,
   type IEditorController,
+  LINE_COLOR_PALETTE,
+  type LineColorOption,
   type LineInterpolation,
   type LineKind,
   type PlayerShape,
@@ -70,7 +72,7 @@ export class PropertyPanel extends Disposable {
       this.addSelect("補間", INTERPOLATIONS, line.interpolation, (v) =>
         controller.updateSelectedLine({ interpolation: v }),
       );
-      this.addColor("色", line.color, (v) => controller.updateSelectedLine({ color: v }));
+      this.addLineColor(line.color, (v) => controller.updateSelectedLine({ color: v }));
       this.addNumber("太さ", line.thickness ?? 2, (v) =>
         controller.updateSelectedLine({ thickness: v }),
       );
@@ -131,6 +133,34 @@ export class PropertyPanel extends Disposable {
     input.value = toHex(value, "#1e3fae");
     input.addEventListener("change", () => onChange(input.value));
     this.addRow(labelText, input);
+  }
+
+  // 線色は自由選択ではなく既定パレットに絞る。スウォッチ色はテーマの
+  // --playmaker-* から解決し、host の上書きに追従する（未定義なら fallback）。
+  private addLineColor(value: string | undefined, onChange: (v: string) => void): void {
+    const styles = getComputedStyle(this.element);
+    const resolve = (opt: LineColorOption): string => {
+      const v = styles.getPropertyValue(opt.cssVar).trim();
+      return v !== "" ? v : opt.fallback;
+    };
+    const group = document.createElement("div");
+    group.className = "playmaker-panel__swatches";
+    for (const opt of LINE_COLOR_PALETTE) {
+      const color = resolve(opt);
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "playmaker-panel__swatch";
+      btn.title = opt.label;
+      btn.setAttribute("aria-label", opt.label);
+      btn.style.backgroundColor = color;
+      btn.setAttribute(
+        "aria-pressed",
+        String(value !== undefined && value.toLowerCase() === color.toLowerCase()),
+      );
+      btn.addEventListener("click", () => onChange(color));
+      group.appendChild(btn);
+    }
+    this.addRow("色", group);
   }
 
   private addSelect<T extends string>(

--- a/src/common/commands/line-commands.test.ts
+++ b/src/common/commands/line-commands.test.ts
@@ -5,6 +5,7 @@ import { PlayModel } from "../model/play-model.js";
 import {
   AddLineCommand,
   RemoveLineCommand,
+  SetLineEndCommand,
   SetLineWaypointsCommand,
   UpdateLineCommand,
 } from "./line-commands.js";
@@ -142,5 +143,31 @@ describe("SetLineWaypointsCommand", () => {
       /unknown line id "ghost"/,
     );
     expect(() => new SetLineWaypointsCommand("l1", []).undo(model)).toThrow(/apply 未実行/);
+  });
+});
+
+describe("SetLineEndCommand", () => {
+  it("終点だけを差し替え waypoint は不変、undo で元へ戻す。構築後の改変は無効", () => {
+    const model = new PlayModel(seed());
+    const end = { lateralYard: 12, absoluteYard: 70 };
+    const cmd = new SetLineEndCommand("l1", end);
+    end.lateralYard = 999;
+
+    cmd.apply(model);
+    expect(model.findLine("l1")?.end).toEqual({ lateralYard: 12, absoluteYard: 70 });
+    expect(model.findLine("l1")?.waypoints).toEqual([]);
+
+    cmd.undo(model);
+    expect(model.findLine("l1")?.end).toEqual({ lateralYard: 5, absoluteYard: 60 });
+  });
+
+  it("未知 id の apply と apply 前 undo は throw する", () => {
+    const model = new PlayModel(seed());
+    const end = { lateralYard: 0, absoluteYard: 0 };
+
+    expect(() => new SetLineEndCommand("ghost", end).apply(model)).toThrow(
+      /unknown line id "ghost"/,
+    );
+    expect(() => new SetLineEndCommand("l1", end).undo(model)).toThrow(/apply 未実行/);
   });
 });

--- a/src/common/commands/line-commands.ts
+++ b/src/common/commands/line-commands.ts
@@ -125,3 +125,32 @@ export class SetLineWaypointsCommand implements ICommand {
     model.updateLine(this.previous);
   }
 }
+
+/** 線の終点を移動する。waypoint と独立に end だけを差し替える可逆プリミティブ。 */
+export class SetLineEndCommand implements ICommand {
+  readonly label = "終点の移動";
+  private readonly end: FieldPosition;
+  private previous: Line | undefined;
+
+  constructor(
+    private readonly lineId: string,
+    end: FieldPosition,
+  ) {
+    this.end = { ...end };
+  }
+
+  apply(model: IPlayModel): void {
+    const current = model.findLine(this.lineId);
+    if (current === undefined) {
+      throw new Error(`SetLineEndCommand: unknown line id "${this.lineId}"`);
+    }
+    this.previous = model.updateLine({ ...current, end: { ...this.end } });
+  }
+
+  undo(model: IPlayModel): void {
+    if (this.previous === undefined) {
+      throw new Error("SetLineEndCommand.undo: apply 未実行");
+    }
+    model.updateLine(this.previous);
+  }
+}

--- a/src/common/design/line-palette.ts
+++ b/src/common/design/line-palette.ts
@@ -1,0 +1,18 @@
+// 線色の選択肢（自由色ではなく既定パレットに絞る）。色そのものはテーマ既定の
+// --playmaker-* トークンに紐づけ、host が上書きすればスウォッチも追従する。
+// canvas は var() を解釈しないため、保存する Line.color は常に解決済みの具体色にする
+// （cssVar は表示・解決のためのヒント、fallback は変数未定義時の具体色）。
+
+export interface LineColorOption {
+  readonly label: string;
+  readonly cssVar: string;
+  readonly fallback: string;
+}
+
+/** 既定テーマ色から視認性の高い 4 色を採る（金=ライン既定 / 白 / 紺 / 橙）。 */
+export const LINE_COLOR_PALETTE: readonly LineColorOption[] = [
+  { label: "金", cssVar: "--playmaker-line-route-color", fallback: "#c49a3c" },
+  { label: "白", cssVar: "--playmaker-player-stroke", fallback: "#eef2ec" },
+  { label: "紺", cssVar: "--playmaker-player-fill", fallback: "#2b4c72" },
+  { label: "橙", cssVar: "--playmaker-pylon-color", fallback: "#d06a30" },
+];

--- a/src/common/editing/editor-controller.test.ts
+++ b/src/common/editing/editor-controller.test.ts
@@ -184,6 +184,33 @@ describe("EditorController: 線の作図（draw-line）", () => {
     expect(controller.getViewState().drawing).toBe(false);
   });
 
+  it("確定後は select ツールへ戻す（連続作図せず編集導線へ）", () => {
+    const { controller } = setup();
+    controller.setTool("draw-line");
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a
+    controller.pointerDown({ lateralYard: 18, absoluteYard: 60 }); // end
+
+    controller.commitLine();
+
+    expect(controller.getTool()).toBe("select");
+  });
+
+  it("直前点とほぼ同座標の打点は無視する（ダブルクリック確定の重複点を防ぐ）", () => {
+    const { controller, model } = setup();
+    controller.setTool("draw-line");
+    controller.pointerDown({ lateralYard: 10, absoluteYard: 50 }); // p-a
+    controller.pointerDown({ lateralYard: 18, absoluteYard: 60 }); // end（1 度目）
+    controller.pointerDown({ lateralYard: 18.1, absoluteYard: 60 }); // dblclick の 2 度目相当
+
+    controller.commitLine();
+
+    // 終点直上に重複 waypoint を作らない＝不可視の折れ線が生まれない。
+    expect(model.getData().lines[1]).toMatchObject({
+      waypoints: [],
+      end: { lateralYard: 18, absoluteYard: 60 },
+    });
+  });
+
   it("点が無いまま確定すると線を追加せず作図を破棄する", () => {
     const { controller, model, changes } = setup();
     controller.setTool("draw-line");
@@ -466,6 +493,108 @@ describe("EditorController: waypoint 編集", () => {
   });
 });
 
+describe("EditorController: 終点（endpoint）編集", () => {
+  it("終点を掴んでドラッグし、end だけ更新・他線/waypoint 不変・undo 可", () => {
+    const { controller, model, undoRedo } = setup({
+      version: 1,
+      field: { zone: "middle" },
+      players: [
+        { id: "p-a", position: { lateralYard: 10, absoluteYard: 50 }, shape: "circle", label: "A" },
+      ],
+      lines: [
+        {
+          id: "l-1",
+          kind: "route",
+          startPlayerId: "p-a",
+          waypoints: [{ lateralYard: 15, absoluteYard: 52 }],
+          end: { lateralYard: 25, absoluteYard: 55 },
+          interpolation: "straight",
+        },
+        {
+          id: "l-2",
+          kind: "block",
+          startPlayerId: "p-a",
+          waypoints: [],
+          end: { lateralYard: 5, absoluteYard: 45 },
+          interpolation: "straight",
+        },
+      ],
+    });
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 選択
+
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // 終点ハンドルを掴む
+    controller.pointerMove({ lateralYard: 28, absoluteYard: 58 });
+    // overlay/プレビューに drag-endpoint が反映され、他線は不変。
+    expect(controller.getOverlay().endpointHandle).toEqual({ lateralYard: 28, absoluteYard: 58 });
+    const rendered = controller.getRenderModel();
+    expect(rendered.lines.find((l) => l.id === "l-1")?.end).toEqual({
+      lateralYard: 28,
+      absoluteYard: 58,
+    });
+    expect(rendered.lines.find((l) => l.id === "l-2")?.end).toEqual({
+      lateralYard: 5,
+      absoluteYard: 45,
+    });
+    controller.pointerUp({ lateralYard: 28, absoluteYard: 58 });
+
+    expect(model.findLine("l-1")?.end).toEqual({ lateralYard: 28, absoluteYard: 58 });
+    expect(model.findLine("l-1")?.waypoints).toEqual([{ lateralYard: 15, absoluteYard: 52 }]);
+
+    undoRedo.undo();
+    expect(model.findLine("l-1")?.end).toEqual({ lateralYard: 25, absoluteYard: 55 });
+  });
+
+  it("終点を掴んで動かさず離せばコマンドを出さない", () => {
+    const { controller, undoRedo } = setup();
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 選択
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // 終点を掴む
+    controller.pointerUp({ lateralYard: 25, absoluteYard: 55 });
+
+    expect(undoRedo.canUndo).toBe(false);
+  });
+
+  it("終点ドラッグ中に線が消えたら離してもコマンドを出さない", () => {
+    const { controller, commands, model } = setup();
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // l-1 選択
+    controller.pointerDown({ lateralYard: 25, absoluteYard: 55 }); // 終点を掴む
+    commands.execute(new RemoveLineCommand("l-1"));
+
+    controller.pointerMove({ lateralYard: 28, absoluteYard: 58 });
+    expect(() => controller.pointerUp({ lateralYard: 28, absoluteYard: 58 })).not.toThrow();
+    expect(model.getData().lines).toHaveLength(0);
+  });
+
+  it("終点と waypoint が近接でも終点を優先して掴む", () => {
+    const { controller, model } = setup({
+      version: 1,
+      field: { zone: "middle" },
+      players: [
+        { id: "p-a", position: { lateralYard: 10, absoluteYard: 50 }, shape: "circle", label: "A" },
+      ],
+      lines: [
+        {
+          id: "l-x",
+          kind: "route",
+          startPlayerId: "p-a",
+          waypoints: [{ lateralYard: 20, absoluteYard: 60 }],
+          end: { lateralYard: 20.2, absoluteYard: 60 }, // waypoint とほぼ同座標
+          interpolation: "straight",
+        },
+      ],
+    });
+    controller.pointerDown({ lateralYard: 15, absoluteYard: 55 }); // l-x 上を選択
+    expect(controller.getSelection()).toEqual({ kind: "line", id: "l-x" });
+
+    controller.pointerDown({ lateralYard: 20.2, absoluteYard: 60 }); // 重なり領域を掴む
+    controller.pointerMove({ lateralYard: 30, absoluteYard: 65 });
+    controller.pointerUp({ lateralYard: 30, absoluteYard: 65 });
+
+    // 終点が動き、waypoint は残る（先端ドラッグが waypoint に奪われない）。
+    expect(model.findLine("l-x")?.end).toEqual({ lateralYard: 30, absoluteYard: 65 });
+    expect(model.findLine("l-x")?.waypoints).toEqual([{ lateralYard: 20, absoluteYard: 60 }]);
+  });
+});
+
 describe("EditorController: アクション", () => {
   it("deleteSelection: 無選択では何もしない", () => {
     const { controller, changes } = setup();
@@ -674,6 +803,7 @@ describe("EditorController: getOverlay / getSelected*", () => {
     expect(controller.getOverlay()).toEqual({
       selectedLineId: "l-1",
       waypointHandles: [{ lateralYard: 15, absoluteYard: 52 }],
+      endpointHandle: { lateralYard: 25, absoluteYard: 55 },
     });
     expect(controller.getSelectedLine()).toMatchObject({ id: "l-1" });
 

--- a/src/common/editing/editor-controller.ts
+++ b/src/common/editing/editor-controller.ts
@@ -16,6 +16,7 @@ import {
   AddLineCommand,
   type LinePatch,
   RemoveLineCommand,
+  SetLineEndCommand,
   SetLineWaypointsCommand,
   UpdateLineCommand,
 } from "../commands/line-commands.js";
@@ -46,8 +47,13 @@ export type EditorSelection =
   | { readonly kind: "line"; readonly id: string }
   | null;
 
-/** 選択中の線の waypoint をドラッグでき、その当たり半径（ヤード）。 */
+/** 選択中の線の waypoint / 終点ハンドルをドラッグでき、その当たり半径（ヤード）。 */
 export const WAYPOINT_HANDLE_RADIUS_YARDS = 0.9;
+
+// 作図中、直前点とこの距離（ヤード）以内のクリックは同一点とみなし打点しない。
+// ダブルクリック確定は pointerdown を 2 度発火させ終点直上に重複点（＝不可視の
+// 折れ線）を生むため、それを構造的に防ぐ。手動の意図的な近接打点は実用上ない粒度。
+const LINE_POINT_MERGE_RADIUS_YARDS = 0.5;
 
 /** プレビュー専用の合成線 id。Model には決して入らない（getRenderModel の中だけ）。 */
 const DRAFT_LINE_ID = "__playmaker_draft_line__";
@@ -61,6 +67,8 @@ export interface EditorOverlay {
   selectedLineId?: string;
   /** 選択中の線の waypoint ハンドル位置（ドラッグ対象）。それ以外は空配列。 */
   waypointHandles: FieldPosition[];
+  /** 選択中の線の終点ハンドル位置（ドラッグ対象）。線未選択なら undefined。 */
+  endpointHandle?: FieldPosition;
 }
 
 /** ツールバー/プロパティパネルが描画に使う集約ビュー状態。 */
@@ -125,6 +133,14 @@ type Interaction =
       current: FieldPosition;
     }
   | {
+      readonly type: "drag-endpoint";
+      readonly lineId: string;
+      readonly origin: FieldPosition;
+      readonly offsetLat: number;
+      readonly offsetAbs: number;
+      current: FieldPosition;
+    }
+  | {
       readonly type: "draw-line";
       readonly startPlayerId: string;
       readonly points: FieldPosition[];
@@ -134,6 +150,12 @@ type Interaction =
 
 function samePosition(a: FieldPosition, b: FieldPosition): boolean {
   return a.lateralYard === b.lateralYard && a.absoluteYard === b.absoluteYard;
+}
+
+// 2 点間距離（ヤード）。geometry の primitive を退化線分（同一点 = 点距離）として
+// 再利用し、ハンドル当たり・近接判定の距離計算を一本化する。
+function pointDistance(a: FieldPosition, b: FieldPosition): number {
+  return distanceToSegment(a, b, b);
 }
 
 function sameSelection(a: EditorSelection, b: EditorSelection): boolean {
@@ -223,6 +245,12 @@ export class EditorController extends Disposable implements IEditorController {
         ),
       };
     }
+    if (i.type === "drag-endpoint") {
+      return {
+        ...data,
+        lines: data.lines.map((l) => (l.id === i.lineId ? { ...l, end: { ...i.current } } : l)),
+      };
+    }
     // draw-line: 起点選手 → 既存 points → 追従カーソルを終点としたプレビュー線を足す。
     return {
       ...data,
@@ -255,6 +283,10 @@ export class EditorController extends Disposable implements IEditorController {
             ? { ...drag.current }
             : w,
         );
+        overlay.endpointHandle =
+          drag?.type === "drag-endpoint" && drag.lineId === s.id
+            ? { ...drag.current }
+            : { ...line.end };
       }
     }
     return overlay;
@@ -339,6 +371,10 @@ export class EditorController extends Disposable implements IEditorController {
       this._onDidChange.fire();
       return;
     }
+    if (i.type === "drag-endpoint") {
+      this.commands.execute(new SetLineEndCommand(i.lineId, final));
+      return;
+    }
     const waypoints = line.waypoints.map((w, idx) => (idx === i.index ? final : w));
     this.commands.execute(new SetLineWaypointsCommand(i.lineId, waypoints));
   }
@@ -379,6 +415,9 @@ export class EditorController extends Disposable implements IEditorController {
       interpolation: DEFAULT_LINE_INTERPOLATION,
     };
     this.commands.execute(new AddLineCommand(line));
+    // 作図直後は選択モードへ戻し、引いた線を選択する（連続作図より編集導線を優先）。
+    // ツール遷移は setTool に集約する（同値ガード・interaction 破棄・発火を一本化）。
+    this.setTool("select");
     this.setSelection({ kind: "line", id });
   }
 
@@ -467,11 +506,26 @@ export class EditorController extends Disposable implements IEditorController {
 
   private selectPointerDown(pos: FieldPosition): void {
     const data = this.model.getData();
-    // 1) 選択中の線の waypoint ハンドルを最優先で掴む（選手/線と重なっても編集可能に）。
+    // 1) 選択中の線のハンドルを最優先で掴む（選手/線と重なっても編集可能に）。
+    //    終点 → waypoint の順で当てる（先端を動かしたい操作を最後の waypoint に
+    //    奪われないよう、終点を先に拾う）。
     const s = this.selection;
     if (s?.kind === "line") {
       const line = data.lines.find((l) => l.id === s.id);
       if (line !== undefined) {
+        if (this.hitEndpoint(line, pos)) {
+          const origin = { ...line.end };
+          this.interaction = {
+            type: "drag-endpoint",
+            lineId: line.id,
+            origin,
+            offsetLat: origin.lateralYard - pos.lateralYard,
+            offsetAbs: origin.absoluteYard - pos.absoluteYard,
+            current: { ...origin },
+          };
+          this._onDidChange.fire();
+          return;
+        }
         const index = this.hitWaypoint(line, pos);
         if (index !== undefined) {
           const origin = line.waypoints[index] as FieldPosition;
@@ -518,8 +572,13 @@ export class EditorController extends Disposable implements IEditorController {
   private drawLinePointerDown(pos: FieldPosition): void {
     const i = this.interaction;
     if (i?.type === "draw-line") {
-      // 作図中: クリックごとに中継点を打つ（最後の点が終点になる）。
-      i.points.push({ ...pos });
+      // 作図中: クリックごとに中継点を打つ（最後の点が終点になる）。直前点と
+      // ほぼ同座標なら打点せずカーソルだけ進める（ダブルクリック確定で生じる
+      // 終点直上の重複点＝不可視の折れ線を防ぐ）。
+      const last = i.points[i.points.length - 1];
+      if (last === undefined || !this.nearPoint(last, pos)) {
+        i.points.push({ ...pos });
+      }
       i.cursor = { ...pos };
       this._onDidChange.fire();
       return;
@@ -551,12 +610,19 @@ export class EditorController extends Disposable implements IEditorController {
     this.setSelection({ kind: "player", id });
   }
 
+  private hitEndpoint(line: Line, pos: FieldPosition): boolean {
+    return pointDistance(pos, line.end) <= WAYPOINT_HANDLE_RADIUS_YARDS;
+  }
+
+  private nearPoint(a: FieldPosition, b: FieldPosition): boolean {
+    return pointDistance(a, b) <= LINE_POINT_MERGE_RADIUS_YARDS;
+  }
+
   private hitWaypoint(line: Line, pos: FieldPosition): number | undefined {
-    // 末尾優先（後の waypoint ほど手前に描く想定に合わせる）。点距離は
-    // geometry の primitive（退化線分 = 点距離）を再利用し当たり計算を一本化する。
+    // 末尾優先（後の waypoint ほど手前に描く想定に合わせる）。
     for (let idx = line.waypoints.length - 1; idx >= 0; idx--) {
       const w = line.waypoints[idx] as FieldPosition;
-      if (distanceToSegment(pos, w, w) <= WAYPOINT_HANDLE_RADIUS_YARDS) {
+      if (pointDistance(pos, w) <= WAYPOINT_HANDLE_RADIUS_YARDS) {
         return idx;
       }
     }

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -12,6 +12,7 @@ export {
   AddLineCommand,
   type LinePatch,
   RemoveLineCommand,
+  SetLineEndCommand,
   SetLineWaypointsCommand,
   UpdateLineCommand,
 } from "./commands/line-commands.js";
@@ -23,6 +24,7 @@ export {
   UpdatePlayerCommand,
 } from "./commands/player-commands.js";
 export { FIELD_FONT_FAMILY } from "./design/field-font.js";
+export { LINE_COLOR_PALETTE, type LineColorOption } from "./design/line-palette.js";
 export { computeFieldMetrics, type FieldMetrics } from "./design/metrics.js";
 export {
   EditorController,

--- a/src/styles.css
+++ b/src/styles.css
@@ -174,6 +174,26 @@
   padding: 0;
 }
 
+.playmaker-panel__swatches {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 6px;
+}
+
+.playmaker-panel__swatch {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.playmaker-panel__swatch[aria-pressed="true"] {
+  outline: 2px solid currentColor;
+  outline-offset: 1px;
+}
+
 /* view モードでは編集 UI を出さない（PRD 5.5）。保険として CSS でも隠す。 */
 .playmaker-root[data-mode="view"] .playmaker-toolbar,
 .playmaker-root[data-mode="view"] .playmaker-panel {


### PR DESCRIPTION
### Summary

線を引く処理まわりの操作性を 3 点整える。

### Checklist

- [x] Code builds and unit tests pass locally
- [x] Relevant documentation updated
- [x] Reviewer has sufficient context

### Motivation and Context

線の編集で以下の不便があった。<br>
- 先端(終点)を動かそうとすると折れ線が増えてしまう。<br>
- 線を引き終えても作図モードのままで、すぐに編集へ移れない。<br>
- 色が自由選択で、図の色がばらつきやすい。<br>

### Implementation Details

**先端の移動**: 終点に専用のドラッグハンドル(円)を追加し、`SetLineEndCommand` で `end` だけを更新できるようにした。<br>
従来は終点にハンドルが無く、ダブルクリック確定が `pointerdown` を 2 度発火させて終点直上に重複点(不可視の waypoint)を生み、それを掴んで動かすと折れ線が増えて見えていた。作図中に直前点とほぼ同座標の打点を無視するガードで、この重複点を構造的に断つ。<br>
**作図後の選択モード**: 確定後は `select` ツールへ戻し、引いた線を選択状態にする。<br>
**色パレット**: 自由選択をやめ、既定テーマ色ベースのスウォッチ(金/白/紺/橙)に絞る。スウォッチ色は `--playmaker-*` から解決するため host のテーマ上書きに追従する。<br>

### Testing Instructions

`pnpm run test`(common 100% カバレッジゲート込み) / `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` がすべてグリーン。<br>
終点ドラッグ・重複点除去・確定後のツール切替・終点コマンドの apply/undo に単体テストを追加。<br>

### Related Issues

なし。

### Notes for Release

線の先端を直接ドラッグで動かせるようになり、線色は既定パレットからの選択に変わります。
